### PR TITLE
[T39] master マージ時の自動タグ・リリース作成（GitHub Actions）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version from package.json
+        id: version
+        run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
+
+      - name: Check if tag exists
+        id: tag_check
+        run: |
+          if git ls-remote --tags origin "v${{ steps.version.outputs.version }}" | grep -q .; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create GitHub Release
+        if: steps.tag_check.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: v${{ steps.version.outputs.version }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true


### PR DESCRIPTION
## Summary

- `.github/workflows/release.yml` を追加
- `master` への push をトリガーに `package.json` の `version` を読み取り、GitHub Release とタグを自動作成
- 同名タグが既存の場合はスキップ（二重作成防止）
- [daily-hub の release.yml](https://github.com/ot-nemoto/daily-hub/blob/master/.github/workflows/release.yml) を踏襲

## Test plan

- [ ] `master` へのマージ後、Actions が起動することを確認
- [ ] `v{package.json の version}` タグ・リリースが作成されることを確認
- [ ] 同じバージョンで再マージしてもタグが重複しないことを確認

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)