### PR TITLE
feat: T80 Prismaフィールド名をcamelCaseに統一

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,20 @@ npm run dev
 - コメント: 自明でないロジックにのみ付ける（過剰なコメント不要）
 - エラーハンドリング: 外部入力・APIレスポンスの境界でのみ行う
 
+## Prisma スキーマのカラム名ルール
+
+- Prisma フィールド名は **camelCase**（TypeScript との一貫性）
+- DB カラム名は **snake_case**（PostgreSQL の慣習）
+- 必ず `@map("snake_case_name")` で明示的にマッピングする
+
+```prisma
+// 例
+clerkId      String?  @unique @map("clerk_id")
+isActive     Boolean  @default(true) @map("is_active")
+createdAt    DateTime @default(now()) @map("created_at")
+invitedById  String   @map("invited_by_id")
+```
+
 ---
 
 ## GitHub Issues 管理ルール

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,77 +23,77 @@ enum Score {
 // ─── Models ───────────────────────────────────────────────────────────────────
 
 model User {
-  id                      String    @id @default(uuid())
-  clerk_id                String?   @unique @db.VarChar(255)
-  email                   String    @unique @db.VarChar(255)
-  name                    String    @db.VarChar(100)
-  division                String?   @db.VarChar(100)
-  joined_at               DateTime? @db.Date
-  role                    UserRole
-  wants_president_meeting Boolean   @default(false)
-  is_active               Boolean   @default(true)
-  created_at              DateTime  @default(now())
-  updated_at              DateTime  @updatedAt
+  id                    String    @id @default(uuid())
+  clerkId               String?   @unique @map("clerk_id") @db.VarChar(255)
+  email                 String    @unique @db.VarChar(255)
+  name                  String    @db.VarChar(100)
+  division              String?   @db.VarChar(100)
+  joinedAt              DateTime? @map("joined_at") @db.Date
+  role                  UserRole
+  wantsPresidentMeeting Boolean   @default(false) @map("wants_president_meeting")
+  isActive              Boolean   @default(true) @map("is_active")
+  createdAt             DateTime  @default(now()) @map("created_at")
+  updatedAt             DateTime  @updatedAt @map("updated_at")
 
-  evaluatee_assignments EvaluationAssignment[] @relation("EvaluateeAssignments")
-  evaluator_assignments EvaluationAssignment[] @relation("EvaluatorAssignments")
-  evaluations           Evaluation[]
-  evaluation_settings   EvaluationSetting[]
+  evaluateeAssignments EvaluationAssignment[] @relation("EvaluateeAssignments")
+  evaluatorAssignments EvaluationAssignment[] @relation("EvaluatorAssignments")
+  evaluations          Evaluation[]
+  evaluationSettings   EvaluationSetting[]
 
   @@map("users")
 }
 
 model FiscalYear {
-  year       Int      @id
-  name       String   @db.VarChar(50)
-  start_date DateTime @db.Date
-  end_date   DateTime @db.Date
-  is_current Boolean  @default(false) // 部分ユニークインデックスで true は最大1件（migration で管理）
-  created_at DateTime @default(now())
+  year      Int      @id
+  name      String   @db.VarChar(50)
+  startDate DateTime @map("start_date") @db.Date
+  endDate   DateTime @map("end_date") @db.Date
+  isCurrent Boolean  @default(false) @map("is_current") // 部分ユニークインデックスで true は最大1件（migration で管理）
+  createdAt DateTime @default(now()) @map("created_at")
 
-  fiscal_year_items    FiscalYearItem[]
-  evaluation_settings  EvaluationSetting[]
-  evaluation_assignments EvaluationAssignment[]
+  fiscalYearItems      FiscalYearItem[]
+  evaluationSettings   EvaluationSetting[]
+  evaluationAssignments EvaluationAssignment[]
   evaluations          Evaluation[]
 
   @@map("fiscal_years")
 }
 
 model FiscalYearItem {
-  fiscal_year         Int
-  evaluation_item_id  Int
+  fiscalYear       Int @map("fiscal_year")
+  evaluationItemId Int @map("evaluation_item_id")
 
-  fiscal_year_rel  FiscalYear     @relation(fields: [fiscal_year], references: [year])
-  evaluation_item  EvaluationItem @relation(fields: [evaluation_item_id], references: [id])
+  fiscalYearRel  FiscalYear     @relation(fields: [fiscalYear], references: [year])
+  evaluationItem EvaluationItem @relation(fields: [evaluationItemId], references: [id])
 
-  @@id([fiscal_year, evaluation_item_id])
+  @@id([fiscalYear, evaluationItemId])
   @@map("fiscal_year_items")
 }
 
 model EvaluationSetting {
-  id                      String  @id @default(uuid())
-  user_id                 String
-  fiscal_year             Int
-  self_evaluation_enabled Boolean @default(false)
+  id                    String  @id @default(uuid())
+  userId                String  @map("user_id")
+  fiscalYear            Int     @map("fiscal_year")
+  selfEvaluationEnabled Boolean @default(false) @map("self_evaluation_enabled")
 
-  user        User       @relation(fields: [user_id], references: [id])
-  fiscal_year_rel FiscalYear @relation(fields: [fiscal_year], references: [year])
+  user          User       @relation(fields: [userId], references: [id])
+  fiscalYearRel FiscalYear @relation(fields: [fiscalYear], references: [year])
 
-  @@unique([user_id, fiscal_year])
+  @@unique([userId, fiscalYear])
   @@map("evaluation_settings")
 }
 
 model EvaluationAssignment {
-  id           String @id @default(uuid())
-  fiscal_year  Int
-  evaluatee_id String
-  evaluator_id String
+  id          String @id @default(uuid())
+  fiscalYear  Int    @map("fiscal_year")
+  evaluateeId String @map("evaluatee_id")
+  evaluatorId String @map("evaluator_id")
 
-  evaluatee       User       @relation("EvaluateeAssignments", fields: [evaluatee_id], references: [id])
-  evaluator       User       @relation("EvaluatorAssignments", fields: [evaluator_id], references: [id])
-  fiscal_year_rel FiscalYear @relation(fields: [fiscal_year], references: [year])
+  evaluatee     User       @relation("EvaluateeAssignments", fields: [evaluateeId], references: [id])
+  evaluator     User       @relation("EvaluatorAssignments", fields: [evaluatorId], references: [id])
+  fiscalYearRel FiscalYear @relation(fields: [fiscalYear], references: [year])
 
-  @@unique([fiscal_year, evaluatee_id, evaluator_id])
+  @@unique([fiscalYear, evaluateeId, evaluatorId])
   @@map("evaluation_assignments")
 }
 
@@ -102,57 +102,57 @@ model Target {
   name String @db.VarChar(100)
   no   Int    @unique
 
-  categories       Category[]
-  evaluation_items EvaluationItem[]
+  categories      Category[]
+  evaluationItems EvaluationItem[]
 
   @@map("targets")
 }
 
 model Category {
-  id        Int    @id @default(autoincrement())
-  target_id Int
-  name      String @db.VarChar(100)
-  no        Int
+  id       Int    @id @default(autoincrement())
+  targetId Int    @map("target_id")
+  name     String @db.VarChar(100)
+  no       Int
 
-  target           Target           @relation(fields: [target_id], references: [id])
-  evaluation_items EvaluationItem[]
+  target          Target           @relation(fields: [targetId], references: [id])
+  evaluationItems EvaluationItem[]
 
-  @@unique([target_id, no])
+  @@unique([targetId, no])
   @@map("categories")
 }
 
 model EvaluationItem {
-  id            Int     @id @default(autoincrement())
-  target_id     Int
-  category_id   Int
-  no            Int
-  name          String  @db.VarChar(255)
-  description   String? @db.Text
-  eval_criteria String? @db.Text
+  id           Int     @id @default(autoincrement())
+  targetId     Int     @map("target_id")
+  categoryId   Int     @map("category_id")
+  no           Int
+  name         String  @db.VarChar(255)
+  description  String? @db.Text
+  evalCriteria String? @map("eval_criteria") @db.Text
 
-  target            Target           @relation(fields: [target_id], references: [id])
-  category          Category         @relation(fields: [category_id], references: [id])
-  evaluations       Evaluation[]
-  fiscal_year_items FiscalYearItem[]
+  target          Target           @relation(fields: [targetId], references: [id])
+  category        Category         @relation(fields: [categoryId], references: [id])
+  evaluations     Evaluation[]
+  fiscalYearItems FiscalYearItem[]
 
-  @@unique([category_id, no])
+  @@unique([categoryId, no])
   @@map("evaluation_items")
 }
 
 model Evaluation {
-  id             String  @id @default(uuid())
-  fiscal_year    Int
-  evaluatee_id   String
-  eval_item_id   Int
-  self_score     Score?
-  self_reason    String? @db.Text
-  manager_score  Score?
-  manager_reason String? @db.Text
+  id            String  @id @default(uuid())
+  fiscalYear    Int     @map("fiscal_year")
+  evaluateeId   String  @map("evaluatee_id")
+  evalItemId    Int     @map("eval_item_id")
+  selfScore     Score?  @map("self_score")
+  selfReason    String? @map("self_reason") @db.Text
+  managerScore  Score?  @map("manager_score")
+  managerReason String? @map("manager_reason") @db.Text
 
-  evaluatee       User           @relation(fields: [evaluatee_id], references: [id])
-  evaluation_item EvaluationItem @relation(fields: [eval_item_id], references: [id])
-  fiscal_year_rel FiscalYear     @relation(fields: [fiscal_year], references: [year])
+  evaluatee     User           @relation(fields: [evaluateeId], references: [id])
+  evaluationItem EvaluationItem @relation(fields: [evalItemId], references: [id])
+  fiscalYearRel FiscalYear     @relation(fields: [fiscalYear], references: [year])
 
-  @@unique([fiscal_year, evaluatee_id, eval_item_id])
+  @@unique([fiscalYear, evaluateeId, evalItemId])
   @@map("evaluations")
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -49,10 +49,10 @@ async function cleanupUser(email: string): Promise<void> {
   const user = await prisma.user.findUnique({ where: { email } });
   if (!user) return;
   await prisma.evaluationAssignment.deleteMany({
-    where: { OR: [{ evaluatee_id: user.id }, { evaluator_id: user.id }] },
+    where: { OR: [{ evaluateeId: user.id }, { evaluatorId: user.id }] },
   });
-  await prisma.evaluation.deleteMany({ where: { evaluatee_id: user.id } });
-  await prisma.evaluationSetting.deleteMany({ where: { user_id: user.id } });
+  await prisma.evaluation.deleteMany({ where: { evaluateeId: user.id } });
+  await prisma.evaluationSetting.deleteMany({ where: { userId: user.id } });
   await prisma.user.delete({ where: { email } });
   await deleteClerkUser(email);
   console.log(`  deleted: ${email}`);
@@ -64,7 +64,7 @@ async function seedFiscalYearItems(allItemIds: number[]) {
   const years = [2025, 2026, 2027];
   for (const year of years) {
     await prisma.fiscalYearItem.createMany({
-      data: allItemIds.map((id) => ({ fiscal_year: year, evaluation_item_id: id })),
+      data: allItemIds.map((id) => ({ fiscalYear: year, evaluationItemId: id })),
       skipDuplicates: true,
     });
   }
@@ -107,12 +107,12 @@ async function main() {
     const clerkId = await syncClerkUser(data.email);
     const user = await prisma.user.upsert({
       where: { email: data.email },
-      update: { name: data.name, role: data.role, ...(clerkId ? { clerk_id: clerkId } : {}) },
+      update: { name: data.name, role: data.role, ...(clerkId ? { clerkId } : {}) },
       create: {
         email: data.email,
         name: data.name,
         role: data.role,
-        ...(clerkId ? { clerk_id: clerkId } : {}),
+        ...(clerkId ? { clerkId } : {}),
       },
     });
     u[data.email] = user;
@@ -123,18 +123,18 @@ async function main() {
   // 2. 年度マスタ（fiscal_years のみ、fiscal_year_items は後で登録）
   // =========================================================================
   const fiscalYearsBase = [
-    { year: 2025, name: "2025年度", start_date: new Date("2025-04-01"), end_date: new Date("2026-03-31"), is_current: false },
-    { year: 2026, name: "2026年度", start_date: new Date("2026-04-01"), end_date: new Date("2027-03-31"), is_current: true },
-    { year: 2027, name: "2027年度", start_date: new Date("2027-04-01"), end_date: new Date("2028-03-31"), is_current: false },
+    { year: 2025, name: "2025年度", startDate: new Date("2025-04-01"), endDate: new Date("2026-03-31"), isCurrent: false },
+    { year: 2026, name: "2026年度", startDate: new Date("2026-04-01"), endDate: new Date("2027-03-31"), isCurrent: true },
+    { year: 2027, name: "2027年度", startDate: new Date("2027-04-01"), endDate: new Date("2028-03-31"), isCurrent: false },
   ];
   for (const fy of fiscalYearsBase) {
     await prisma.fiscalYear.upsert({
       where: { year: fy.year },
-      update: { name: fy.name, start_date: fy.start_date, end_date: fy.end_date, is_current: fy.is_current },
+      update: { name: fy.name, startDate: fy.startDate, endDate: fy.endDate, isCurrent: fy.isCurrent },
       create: fy,
     });
   }
-  await prisma.fiscalYear.updateMany({ where: { year: { not: 2026 } }, data: { is_current: false } });
+  await prisma.fiscalYear.updateMany({ where: { year: { not: 2026 } }, data: { isCurrent: false } });
   console.log(`fiscal_years: ${fiscalYearsBase.length} upserted`);
 
   // =========================================================================
@@ -149,24 +149,24 @@ async function main() {
   //  里中智      │ true  │ true  │ true
   //  岩鬼正美    │ false │ false │ false  ← デフォルトのため登録不要
   // =========================================================================
-  const settingsData: { email: string; fiscal_year: number; self_evaluation_enabled: boolean }[] = [
-    { email: "shiranui@example.com", fiscal_year: 2025, self_evaluation_enabled: true },
-    { email: "yamada@example.com", fiscal_year: 2025, self_evaluation_enabled: true },
-    { email: "yamada@example.com", fiscal_year: 2026, self_evaluation_enabled: true },
-    { email: "yamada@example.com", fiscal_year: 2027, self_evaluation_enabled: true },
-    { email: "satonaka@example.com", fiscal_year: 2025, self_evaluation_enabled: true },
-    { email: "satonaka@example.com", fiscal_year: 2026, self_evaluation_enabled: true },
-    { email: "satonaka@example.com", fiscal_year: 2027, self_evaluation_enabled: true },
+  const settingsData: { email: string; fiscalYear: number; selfEvaluationEnabled: boolean }[] = [
+    { email: "shiranui@example.com", fiscalYear: 2025, selfEvaluationEnabled: true },
+    { email: "yamada@example.com", fiscalYear: 2025, selfEvaluationEnabled: true },
+    { email: "yamada@example.com", fiscalYear: 2026, selfEvaluationEnabled: true },
+    { email: "yamada@example.com", fiscalYear: 2027, selfEvaluationEnabled: true },
+    { email: "satonaka@example.com", fiscalYear: 2025, selfEvaluationEnabled: true },
+    { email: "satonaka@example.com", fiscalYear: 2026, selfEvaluationEnabled: true },
+    { email: "satonaka@example.com", fiscalYear: 2027, selfEvaluationEnabled: true },
   ];
 
   for (const s of settingsData) {
     await prisma.evaluationSetting.upsert({
-      where: { user_id_fiscal_year: { user_id: u[s.email].id, fiscal_year: s.fiscal_year } },
-      update: { self_evaluation_enabled: s.self_evaluation_enabled },
+      where: { userId_fiscalYear: { userId: u[s.email].id, fiscalYear: s.fiscalYear } },
+      update: { selfEvaluationEnabled: s.selfEvaluationEnabled },
       create: {
-        user_id: u[s.email].id,
-        fiscal_year: s.fiscal_year,
-        self_evaluation_enabled: s.self_evaluation_enabled,
+        userId: u[s.email].id,
+        fiscalYear: s.fiscalYear,
+        selfEvaluationEnabled: s.selfEvaluationEnabled,
       },
     });
   }
@@ -188,31 +188,31 @@ async function main() {
   // =========================================================================
   const assignmentsData = [
     // 2025
-    { fiscal_year: 2025, evaluatee: "shiranui@example.com", evaluator: "doigaki@example.com" },
-    { fiscal_year: 2025, evaluatee: "yamada@example.com", evaluator: "doigaki@example.com" },
-    { fiscal_year: 2025, evaluatee: "satonaka@example.com", evaluator: "shiranui@example.com" },
-    { fiscal_year: 2025, evaluatee: "satonaka@example.com", evaluator: "yamada@example.com" },
+    { fiscalYear: 2025, evaluatee: "shiranui@example.com", evaluator: "doigaki@example.com" },
+    { fiscalYear: 2025, evaluatee: "yamada@example.com", evaluator: "doigaki@example.com" },
+    { fiscalYear: 2025, evaluatee: "satonaka@example.com", evaluator: "shiranui@example.com" },
+    { fiscalYear: 2025, evaluatee: "satonaka@example.com", evaluator: "yamada@example.com" },
     // 2026
-    { fiscal_year: 2026, evaluatee: "yamada@example.com", evaluator: "doigaki@example.com" },
-    { fiscal_year: 2026, evaluatee: "yamada@example.com", evaluator: "shiranui@example.com" },
-    { fiscal_year: 2026, evaluatee: "satonaka@example.com", evaluator: "shiranui@example.com" },
-    { fiscal_year: 2026, evaluatee: "satonaka@example.com", evaluator: "yamada@example.com" },
+    { fiscalYear: 2026, evaluatee: "yamada@example.com", evaluator: "doigaki@example.com" },
+    { fiscalYear: 2026, evaluatee: "yamada@example.com", evaluator: "shiranui@example.com" },
+    { fiscalYear: 2026, evaluatee: "satonaka@example.com", evaluator: "shiranui@example.com" },
+    { fiscalYear: 2026, evaluatee: "satonaka@example.com", evaluator: "yamada@example.com" },
   ];
 
   for (const a of assignmentsData) {
     await prisma.evaluationAssignment.upsert({
       where: {
-        fiscal_year_evaluatee_id_evaluator_id: {
-          fiscal_year: a.fiscal_year,
-          evaluatee_id: u[a.evaluatee].id,
-          evaluator_id: u[a.evaluator].id,
+        fiscalYear_evaluateeId_evaluatorId: {
+          fiscalYear: a.fiscalYear,
+          evaluateeId: u[a.evaluatee].id,
+          evaluatorId: u[a.evaluator].id,
         },
       },
       update: {},
       create: {
-        fiscal_year: a.fiscal_year,
-        evaluatee_id: u[a.evaluatee].id,
-        evaluator_id: u[a.evaluator].id,
+        fiscalYear: a.fiscalYear,
+        evaluateeId: u[a.evaluatee].id,
+        evaluatorId: u[a.evaluator].id,
       },
     });
   }
@@ -254,9 +254,9 @@ async function main() {
   for (const c of categoriesData) {
     const target = targetByName[c.target];
     await prisma.category.upsert({
-      where: { target_id_no: { target_id: target.id, no: c.no } },
+      where: { targetId_no: { targetId: target.id, no: c.no } },
       update: { name: c.name },
-      create: { target_id: target.id, name: c.name, no: c.no },
+      create: { targetId: target.id, name: c.name, no: c.no },
     });
   }
   console.log(`categories: ${categoriesData.length} upserted`);
@@ -274,20 +274,20 @@ async function main() {
     const target = targetByName[item.target];
     const category = categoryByKey[categoryKey(item.target, item.category)];
     await prisma.evaluationItem.upsert({
-      where: { category_id_no: { category_id: category.id, no: item.item_no } },
+      where: { categoryId_no: { categoryId: category.id, no: item.item_no } },
       update: {
-        target_id: target.id,
+        targetId: target.id,
         name: item.name,
         description: item.description ?? null,
-        eval_criteria: item.eval_criteria ?? null,
+        evalCriteria: item.eval_criteria ?? null,
       },
       create: {
-        target_id: target.id,
-        category_id: category.id,
+        targetId: target.id,
+        categoryId: category.id,
         no: item.item_no,
         name: item.name,
         description: item.description ?? null,
-        eval_criteria: item.eval_criteria ?? null,
+        evalCriteria: item.eval_criteria ?? null,
       },
     });
   }

--- a/src/app/(dashboard)/admin/evaluation-items/page.tsx
+++ b/src/app/(dashboard)/admin/evaluation-items/page.tsx
@@ -11,7 +11,7 @@ export default async function EvaluationItemsPage() {
 
   const [targets, categories] = await Promise.all([
     prisma.target.findMany({ orderBy: { no: "asc" }, select: { id: true, name: true } }),
-    prisma.category.findMany({ orderBy: { no: "asc" }, select: { id: true, target_id: true, name: true } }),
+    prisma.category.findMany({ orderBy: { no: "asc" }, select: { id: true, targetId: true, name: true } }),
   ]);
 
   const items = await prisma.evaluationItem.findMany({
@@ -21,10 +21,10 @@ export default async function EvaluationItemsPage() {
       no: true,
       name: true,
       description: true,
-      eval_criteria: true,
+      evalCriteria: true,
       target: { select: { name: true, no: true } },
       category: { select: { name: true, no: true } },
-      _count: { select: { fiscal_year_items: true } },
+      _count: { select: { fiscalYearItems: true } },
     },
   });
 
@@ -65,7 +65,7 @@ export default async function EvaluationItemsPage() {
                   <td className="px-4 py-3 text-gray-700">{item.category.name}</td>
                   <td className="px-4 py-3 text-gray-900">{item.name}</td>
                   <td className="px-4 py-3 text-right">
-                    <EvaluationItemActions item={item} hasEvaluations={item._count.fiscal_year_items > 0} />
+                    <EvaluationItemActions item={item} hasEvaluations={item._count.fiscalYearItems > 0} />
                   </td>
                 </tr>
               ))

--- a/src/app/(dashboard)/admin/fiscal-years/page.tsx
+++ b/src/app/(dashboard)/admin/fiscal-years/page.tsx
@@ -11,7 +11,7 @@ export default async function FiscalYearsPage() {
 
   const fiscalYears = await prisma.fiscalYear.findMany({
     orderBy: { year: "desc" },
-    select: { year: true, name: true, start_date: true, end_date: true, is_current: true },
+    select: { year: true, name: true, startDate: true, endDate: true, isCurrent: true },
   });
 
   return (
@@ -46,17 +46,17 @@ export default async function FiscalYearsPage() {
               </tr>
             ) : (
               fiscalYears.map((fy) => (
-                <tr key={fy.year} className={fy.is_current ? "bg-blue-50" : "hover:bg-gray-50"}>
+                <tr key={fy.year} className={fy.isCurrent ? "bg-blue-50" : "hover:bg-gray-50"}>
                   <td className="px-4 py-3 font-medium text-gray-900">{fy.year}</td>
                   <td className="px-4 py-3 text-gray-700">{fy.name}</td>
                   <td className="px-4 py-3 text-gray-500">
-                    {fy.start_date.toLocaleDateString("ja-JP")}
+                    {fy.startDate.toLocaleDateString("ja-JP")}
                   </td>
                   <td className="px-4 py-3 text-gray-500">
-                    {fy.end_date.toLocaleDateString("ja-JP")}
+                    {fy.endDate.toLocaleDateString("ja-JP")}
                   </td>
                   <td className="px-4 py-3">
-                    {fy.is_current ? (
+                    {fy.isCurrent ? (
                       <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
                         現在
                       </span>

--- a/src/app/(dashboard)/admin/targets/page.tsx
+++ b/src/app/(dashboard)/admin/targets/page.tsx
@@ -17,7 +17,7 @@ export default async function TargetsPage() {
       _count: { select: { categories: true } },
       categories: {
         orderBy: { no: "asc" },
-        include: { _count: { select: { evaluation_items: true } } },
+        include: { _count: { select: { evaluationItems: true } } },
       },
     },
   });
@@ -78,8 +78,8 @@ export default async function TargetsPage() {
                           <td className="py-2 text-gray-700">{cat.name}</td>
                           <td className="py-2 text-right">
                             <CategoryActions
-                              category={{ id: cat.id, target_id: cat.target_id, name: cat.name, no: cat.no }}
-                              canDelete={cat._count.evaluation_items === 0}
+                              category={{ id: cat.id, targetId: cat.targetId, name: cat.name, no: cat.no }}
+                              canDelete={cat._count.evaluationItems === 0}
                             />
                           </td>
                         </tr>

--- a/src/app/(dashboard)/admin/users/[id]/evaluation-settings/page.tsx
+++ b/src/app/(dashboard)/admin/users/[id]/evaluation-settings/page.tsx
@@ -26,10 +26,10 @@ export default async function UserEvaluationSettingsPage({
   const years = [currentFiscalYear - 1, currentFiscalYear, currentFiscalYear + 1];
 
   const settings = await prisma.evaluationSetting.findMany({
-    where: { user_id: id },
+    where: { userId: id },
   });
   const settingMap = Object.fromEntries(
-    settings.map((s) => [s.fiscal_year, s.self_evaluation_enabled]),
+    settings.map((s) => [s.fiscalYear, s.selfEvaluationEnabled]),
   );
 
   return (

--- a/src/app/(dashboard)/admin/users/page.tsx
+++ b/src/app/(dashboard)/admin/users/page.tsx
@@ -16,9 +16,9 @@ export default async function AdminUsersPage() {
       email: true,
       role: true,
       division: true,
-      joined_at: true,
-      created_at: true,
-      is_active: true,
+      joinedAt: true,
+      createdAt: true,
+      isActive: true,
     },
     orderBy: { name: "asc" },
   });
@@ -47,7 +47,7 @@ export default async function AdminUsersPage() {
             {users.map((user) => (
               <tr
                 key={user.id}
-                className={user.is_active ? "hover:bg-gray-50" : "bg-gray-50 opacity-60"}
+                className={user.isActive ? "hover:bg-gray-50" : "bg-gray-50 opacity-60"}
               >
                 <td className="px-4 py-3 font-medium text-gray-900">{user.name}</td>
                 <td className="px-4 py-3 text-gray-500">{user.email}</td>
@@ -64,7 +64,7 @@ export default async function AdminUsersPage() {
                   </span>
                 </td>
                 <td className="px-4 py-3 text-gray-500">
-                  {user.created_at.toLocaleDateString("ja-JP")}
+                  {user.createdAt.toLocaleDateString("ja-JP")}
                 </td>
                 <td className="px-4 py-3">
                   <Link
@@ -78,7 +78,7 @@ export default async function AdminUsersPage() {
                   <UserActions
                     userId={user.id}
                     currentRole={user.role}
-                    isActive={user.is_active}
+                    isActive={user.isActive}
                     isSelf={user.id === session.user.id}
                   />
                 </td>

--- a/src/app/(dashboard)/evaluations/page.tsx
+++ b/src/app/(dashboard)/evaluations/page.tsx
@@ -29,14 +29,14 @@ export default async function EvaluationsPage() {
       include: { target: true, category: true },
     }),
     prisma.evaluation.findMany({
-      where: { evaluatee_id: userId, fiscal_year: fiscalYear },
+      where: { evaluateeId: userId, fiscalYear: fiscalYear },
     }),
     prisma.evaluationSetting.findUnique({
-      where: { user_id_fiscal_year: { user_id: userId, fiscal_year: fiscalYear } },
+      where: { userId_fiscalYear: { userId: userId, fiscalYear: fiscalYear } },
     }),
   ]);
 
-  const selfEvaluationEnabled = setting?.self_evaluation_enabled ?? false;
+  const selfEvaluationEnabled = setting?.selfEvaluationEnabled ?? false;
 
   if (!selfEvaluationEnabled) {
     return (
@@ -52,7 +52,7 @@ export default async function EvaluationsPage() {
     );
   }
 
-  const evalMap = Object.fromEntries(evaluations.map((e) => [e.eval_item_id, e]));
+  const evalMap = Object.fromEntries(evaluations.map((e) => [e.evalItemId, e]));
 
   const itemsWithEval = items.map((item) => {
     const ev = evalMap[item.id];
@@ -61,11 +61,11 @@ export default async function EvaluationsPage() {
       uid: `${item.target.no}-${item.category.no}-${item.no}`,
       name: item.name,
       description: item.description,
-      eval_criteria: item.eval_criteria,
+      evalCriteria: item.evalCriteria,
       category: item.category.name,
       target: item.target.name,
-      self_score: (ev?.self_score ?? null) as "none" | "ka" | "ryo" | "yu" | null,
-      self_reason: ev?.self_reason ?? null,
+      selfScore: (ev?.selfScore ?? null) as "none" | "ka" | "ryo" | "yu" | null,
+      selfReason: ev?.selfReason ?? null,
     };
   });
 

--- a/src/app/(dashboard)/members/[id]/evaluations/page.tsx
+++ b/src/app/(dashboard)/members/[id]/evaluations/page.tsx
@@ -20,10 +20,10 @@ export default async function MemberEvaluationsPage({ params }: Props) {
   if (!isAdmin) {
     const assignment = await prisma.evaluationAssignment.findUnique({
       where: {
-        fiscal_year_evaluatee_id_evaluator_id: {
-          fiscal_year: fiscalYear,
-          evaluatee_id: evaluateeId,
-          evaluator_id: evaluatorId,
+        fiscalYear_evaluateeId_evaluatorId: {
+          fiscalYear: fiscalYear,
+          evaluateeId: evaluateeId,
+          evaluatorId: evaluatorId,
         },
       },
     });
@@ -42,11 +42,11 @@ export default async function MemberEvaluationsPage({ params }: Props) {
       include: { target: true, category: true },
     }),
     prisma.evaluation.findMany({
-      where: { evaluatee_id: evaluateeId, fiscal_year: fiscalYear },
+      where: { evaluateeId: evaluateeId, fiscalYear: fiscalYear },
     }),
   ]);
 
-  const evalMap = Object.fromEntries(evaluations.map((e) => [e.eval_item_id, e]));
+  const evalMap = Object.fromEntries(evaluations.map((e) => [e.evalItemId, e]));
 
   const itemsWithEval = items.map((item) => {
     const ev = evalMap[item.id];
@@ -55,13 +55,13 @@ export default async function MemberEvaluationsPage({ params }: Props) {
       uid: `${item.target.no}-${item.category.no}-${item.no}`,
       name: item.name,
       description: item.description,
-      eval_criteria: item.eval_criteria,
+      evalCriteria: item.evalCriteria,
       category: item.category.name,
       target: item.target.name,
-      self_score: (ev?.self_score ?? null) as "none" | "ka" | "ryo" | "yu" | null,
-      self_reason: ev?.self_reason ?? null,
-      manager_score: (ev?.manager_score ?? null) as "none" | "ka" | "ryo" | "yu" | null,
-      manager_reason: ev?.manager_reason ?? null,
+      selfScore: (ev?.selfScore ?? null) as "none" | "ka" | "ryo" | "yu" | null,
+      selfReason: ev?.selfReason ?? null,
+      managerScore: (ev?.managerScore ?? null) as "none" | "ka" | "ryo" | "yu" | null,
+      managerReason: ev?.managerReason ?? null,
     };
   });
 

--- a/src/app/(dashboard)/members/page.tsx
+++ b/src/app/(dashboard)/members/page.tsx
@@ -22,7 +22,7 @@ export default async function MembersPage() {
     });
   } else if (fiscalYear !== null) {
     const assignments = await prisma.evaluationAssignment.findMany({
-      where: { evaluator_id: userId, fiscal_year: fiscalYear },
+      where: { evaluatorId: userId, fiscalYear: fiscalYear },
       include: { evaluatee: { select: { id: true, name: true, division: true } } },
       orderBy: { evaluatee: { name: "asc" } },
     });

--- a/src/app/api/admin/categories/[id]/route.test.ts
+++ b/src/app/api/admin/categories/[id]/route.test.ts
@@ -16,7 +16,7 @@ import { prisma } from "@/lib/prisma";
 const adminSession = { user: { id: "admin-1", role: "admin" } };
 const memberSession = { user: { id: "member-1", role: "member" } };
 
-const mockCategory = { id: 1, target_id: 1, name: "engagement", no: 1 };
+const mockCategory = { id: 1, targetId: 1, name: "engagement", no: 1 };
 
 function makeRequest(body: unknown) {
   return new Request("http://localhost/api/admin/categories/1", {
@@ -71,7 +71,7 @@ describe("PATCH /api/admin/categories/:id", () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
     vi.mocked(prisma.category.findUnique)
       .mockResolvedValueOnce(mockCategory as never)
-      .mockResolvedValueOnce({ id: 2, target_id: 1, name: "other", no: 2 } as never);
+      .mockResolvedValueOnce({ id: 2, targetId: 1, name: "other", no: 2 } as never);
 
     const res = await PATCH(makeRequest({ no: 2 }), { params: Promise.resolve({ id: "1" }) });
     expect(res.status).toBe(409);

--- a/src/app/api/admin/categories/[id]/route.ts
+++ b/src/app/api/admin/categories/[id]/route.ts
@@ -29,7 +29,7 @@ export async function PATCH(request: Request, { params }: Params) {
 
   if (data.no !== undefined && data.no !== category.no) {
     const conflict = await prisma.category.findUnique({
-      where: { target_id_no: { target_id: category.target_id, no: data.no } },
+      where: { targetId_no: { targetId: category.targetId, no: data.no } },
     });
     if (conflict) return errorResponse("CONFLICT", "同じ target_id と no の中分類がすでに存在します", 409);
   }
@@ -37,7 +37,7 @@ export async function PATCH(request: Request, { params }: Params) {
   const updated = await prisma.category.update({
     where: { id },
     data,
-    select: { id: true, target_id: true, name: true, no: true },
+    select: { id: true, targetId: true, name: true, no: true },
   });
 
   return successResponse(updated);
@@ -55,7 +55,7 @@ export async function DELETE(_request: Request, { params }: Params) {
   const category = await prisma.category.findUnique({ where: { id } });
   if (!category) return errorResponse("NOT_FOUND", "中分類が見つかりません", 404);
 
-  const itemCount = await prisma.evaluationItem.count({ where: { category_id: id } });
+  const itemCount = await prisma.evaluationItem.count({ where: { categoryId: id } });
   if (itemCount > 0) return errorResponse("CONFLICT", "紐づく評価項目が存在するため削除できません", 409);
 
   await prisma.category.delete({ where: { id } });

--- a/src/app/api/admin/categories/[id]/route.ts
+++ b/src/app/api/admin/categories/[id]/route.ts
@@ -31,7 +31,7 @@ export async function PATCH(request: Request, { params }: Params) {
     const conflict = await prisma.category.findUnique({
       where: { targetId_no: { targetId: category.targetId, no: data.no } },
     });
-    if (conflict) return errorResponse("CONFLICT", "同じ target_id と no の中分類がすでに存在します", 409);
+    if (conflict) return errorResponse("CONFLICT", "同じ targetId と no の中分類がすでに存在します", 409);
   }
 
   const updated = await prisma.category.update({

--- a/src/app/api/admin/categories/route.test.ts
+++ b/src/app/api/admin/categories/route.test.ts
@@ -17,8 +17,8 @@ const adminSession = { user: { id: "admin-1", role: "admin" } };
 const memberSession = { user: { id: "member-1", role: "member" } };
 
 const mockCategories = [
-  { id: 1, target_id: 1, name: "engagement", no: 1 },
-  { id: 2, target_id: 1, name: "skill", no: 2 },
+  { id: 1, targetId: 1, name: "engagement", no: 1 },
+  { id: 2, targetId: 1, name: "skill", no: 2 },
 ];
 
 describe("GET /api/admin/categories", () => {
@@ -36,23 +36,23 @@ describe("GET /api/admin/categories", () => {
     expect(body.data).toHaveLength(2);
   });
 
-  it("?target_id でフィルタできる", async () => {
+  it("?targetId でフィルタできる", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
     vi.mocked(prisma.category.findMany).mockResolvedValue([mockCategories[0]] as never);
 
-    const req = new Request("http://localhost/api/admin/categories?target_id=1");
+    const req = new Request("http://localhost/api/admin/categories?targetId=1");
     const res = await GET(req);
     const body = await res.json();
 
     expect(res.status).toBe(200);
     expect(prisma.category.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { target_id: 1 } }),
+      expect.objectContaining({ where: { targetId: 1 } }),
     );
   });
 
-  it("?target_id が不正値の場合は 400", async () => {
+  it("?targetId が不正値の場合は 400", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
-    const res = await GET(new Request("http://localhost/api/admin/categories?target_id=abc"));
+    const res = await GET(new Request("http://localhost/api/admin/categories?targetId=abc"));
     expect(res.status).toBe(400);
   });
 
@@ -80,7 +80,7 @@ describe("POST /api/admin/categories", () => {
 
     const req = new Request("http://localhost/api/admin/categories", {
       method: "POST",
-      body: JSON.stringify({ target_id: 1, name: "engagement", no: 1 }),
+      body: JSON.stringify({ targetId: 1, name: "engagement", no: 1 }),
     });
     const res = await POST(req);
     const body = await res.json();
@@ -93,13 +93,13 @@ describe("POST /api/admin/categories", () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
     const req = new Request("http://localhost/api/admin/categories", {
       method: "POST",
-      body: JSON.stringify({ target_id: 1, name: "", no: 1 }),
+      body: JSON.stringify({ targetId: 1, name: "", no: 1 }),
     });
     const res = await POST(req);
     expect(res.status).toBe(400);
   });
 
-  it("target_id がない場合は 400", async () => {
+  it("targetId がない場合は 400", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
 
     const req = new Request("http://localhost/api/admin/categories", {
@@ -110,26 +110,26 @@ describe("POST /api/admin/categories", () => {
     expect(res.status).toBe(400);
   });
 
-  it("存在しない target_id の場合は 404", async () => {
+  it("存在しない targetId の場合は 404", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
     vi.mocked(prisma.target.findUnique).mockResolvedValue(null);
 
     const req = new Request("http://localhost/api/admin/categories", {
       method: "POST",
-      body: JSON.stringify({ target_id: 999, name: "x", no: 1 }),
+      body: JSON.stringify({ targetId: 999, name: "x", no: 1 }),
     });
     const res = await POST(req);
     expect(res.status).toBe(404);
   });
 
-  it("同じ target_id と no が存在する場合は 409", async () => {
+  it("同じ targetId と no が存在する場合は 409", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
     vi.mocked(prisma.target.findUnique).mockResolvedValue({ id: 1 } as never);
     vi.mocked(prisma.category.findUnique).mockResolvedValue(mockCategories[0] as never);
 
     const req = new Request("http://localhost/api/admin/categories", {
       method: "POST",
-      body: JSON.stringify({ target_id: 1, name: "dup", no: 1 }),
+      body: JSON.stringify({ targetId: 1, name: "dup", no: 1 }),
     });
     const res = await POST(req);
     expect(res.status).toBe(409);
@@ -139,7 +139,7 @@ describe("POST /api/admin/categories", () => {
     vi.mocked(getSession).mockResolvedValue(null);
     const req = new Request("http://localhost/api/admin/categories", {
       method: "POST",
-      body: JSON.stringify({ target_id: 1, name: "x", no: 1 }),
+      body: JSON.stringify({ targetId: 1, name: "x", no: 1 }),
     });
     const res = await POST(req);
     expect(res.status).toBe(401);
@@ -149,7 +149,7 @@ describe("POST /api/admin/categories", () => {
     vi.mocked(getSession).mockResolvedValue(memberSession as never);
     const req = new Request("http://localhost/api/admin/categories", {
       method: "POST",
-      body: JSON.stringify({ target_id: 1, name: "x", no: 1 }),
+      body: JSON.stringify({ targetId: 1, name: "x", no: 1 }),
     });
     const res = await POST(req);
     expect(res.status).toBe(403);

--- a/src/app/api/admin/categories/route.ts
+++ b/src/app/api/admin/categories/route.ts
@@ -9,20 +9,20 @@ export async function GET(request: Request) {
   if (session.user.role !== "admin") return errorResponse("FORBIDDEN", "権限がありません", 403);
 
   const { searchParams } = new URL(request.url);
-  const targetIdStr = searchParams.get("target_id");
-  let where: { target_id?: number } = {};
+  const targetIdStr = searchParams.get("targetId");
+  let where: { targetId?: number } = {};
   if (targetIdStr !== null) {
     const targetId = Number(targetIdStr);
     if (!Number.isInteger(targetId) || targetId < 1) {
-      return errorResponse("BAD_REQUEST", "target_id は正の整数で指定してください", 400);
+      return errorResponse("BAD_REQUEST", "targetId は正の整数で指定してください", 400);
     }
-    where = { target_id: targetId };
+    where = { targetId: targetId };
   }
 
   const categories = await prisma.category.findMany({
     where,
     orderBy: { no: "asc" },
-    select: { id: true, target_id: true, name: true, no: true },
+    select: { id: true, targetId: true, name: true, no: true },
   });
 
   return successResponse(categories);
@@ -36,27 +36,27 @@ export async function POST(request: Request) {
   const body = await request.json().catch(() => null);
   if (
     !body ||
-    !Number.isInteger(body.target_id) ||
-    body.target_id < 1 ||
+    !Number.isInteger(body.targetId) ||
+    body.targetId < 1 ||
     typeof body.name !== "string" ||
     !body.name ||
     !Number.isInteger(body.no) ||
     body.no < 1
   ) {
-    return errorResponse("BAD_REQUEST", "target_id, name, no は必須です", 400);
+    return errorResponse("BAD_REQUEST", "targetId, name, no は必須です", 400);
   }
 
-  const target = await prisma.target.findUnique({ where: { id: body.target_id } });
+  const target = await prisma.target.findUnique({ where: { id: body.targetId } });
   if (!target) return errorResponse("NOT_FOUND", "大分類が見つかりません", 404);
 
   const existing = await prisma.category.findUnique({
-    where: { target_id_no: { target_id: body.target_id, no: body.no } },
+    where: { targetId_no: { targetId: body.targetId, no: body.no } },
   });
-  if (existing) return errorResponse("CONFLICT", "同じ target_id と no の中分類がすでに存在します", 409);
+  if (existing) return errorResponse("CONFLICT", "同じ targetId と no の中分類がすでに存在します", 409);
 
   const created = await prisma.category.create({
-    data: { target_id: body.target_id, name: body.name, no: body.no },
-    select: { id: true, target_id: true, name: true, no: true },
+    data: { targetId: body.targetId, name: body.name, no: body.no },
+    select: { id: true, targetId: true, name: true, no: true },
   });
 
   return successResponse(created, undefined, 201);

--- a/src/app/api/admin/evaluation-items/[id]/route.test.ts
+++ b/src/app/api/admin/evaluation-items/[id]/route.test.ts
@@ -18,14 +18,14 @@ const memberSession = { user: { id: "member-1", role: "member" } };
 
 const mockItem = {
   id: 1,
-  target_id: 1,
-  category_id: 1,
+  targetId: 1,
+  categoryId: 1,
   no: 1,
   name: "会社員としての基本姿勢",
   description: null,
-  eval_criteria: null,
+  evalCriteria: null,
   target: { id: 1, name: "employee", no: 1 },
-  category: { id: 1, target_id: 1, name: "engagement", no: 1 },
+  category: { id: 1, targetId: 1, name: "engagement", no: 1 },
 };
 
 const params = Promise.resolve({ id: "1" });

--- a/src/app/api/admin/evaluation-items/[id]/route.ts
+++ b/src/app/api/admin/evaluation-items/[id]/route.ts
@@ -29,9 +29,9 @@ export async function PATCH(request: Request, { params }: Params) {
     if (body.description !== null && typeof body.description !== "string") return errorResponse("BAD_REQUEST", "description の型が不正です", 400);
     data.description = body.description;
   }
-  if ("eval_criteria" in body) {
-    if (body.eval_criteria !== null && typeof body.eval_criteria !== "string") return errorResponse("BAD_REQUEST", "eval_criteria の型が不正です", 400);
-    data.eval_criteria = body.eval_criteria;
+  if ("evalCriteria" in body) {
+    if (body.evalCriteria !== null && typeof body.evalCriteria !== "string") return errorResponse("BAD_REQUEST", "evalCriteria の型が不正です", 400);
+    data.evalCriteria = body.evalCriteria;
   }
   if (Object.keys(data).length === 0) return errorResponse("BAD_REQUEST", "更新するフィールドを指定してください", 400);
 
@@ -40,14 +40,14 @@ export async function PATCH(request: Request, { params }: Params) {
     data,
     select: {
       id: true,
-      target_id: true,
-      category_id: true,
+      targetId: true,
+      categoryId: true,
       no: true,
       name: true,
       description: true,
-      eval_criteria: true,
+      evalCriteria: true,
       target: { select: { id: true, name: true, no: true } },
-      category: { select: { id: true, target_id: true, name: true, no: true } },
+      category: { select: { id: true, targetId: true, name: true, no: true } },
     },
   });
 
@@ -67,7 +67,7 @@ export async function DELETE(_request: Request, { params }: Params) {
   const existing = await prisma.evaluationItem.findUnique({ where: { id } });
   if (!existing) return errorResponse("NOT_FOUND", "評価項目が見つかりません", 404);
 
-  const linked = await prisma.fiscalYearItem.count({ where: { evaluation_item_id: id } });
+  const linked = await prisma.fiscalYearItem.count({ where: { evaluationItemId: id } });
   if (linked > 0) return errorResponse("CONFLICT", "年度に紐づいているため削除できません", 409);
 
   await prisma.evaluationItem.delete({ where: { id } });

--- a/src/app/api/admin/evaluation-items/route.test.ts
+++ b/src/app/api/admin/evaluation-items/route.test.ts
@@ -18,15 +18,15 @@ const adminSession = { user: { id: "admin-1", role: "admin" } };
 const memberSession = { user: { id: "member-1", role: "member" } };
 
 const mockTarget = { id: 1, name: "employee", no: 1 };
-const mockCategory = { id: 1, target_id: 1, name: "engagement", no: 1 };
+const mockCategory = { id: 1, targetId: 1, name: "engagement", no: 1 };
 const mockItem = {
   id: 1,
-  target_id: 1,
-  category_id: 1,
+  targetId: 1,
+  categoryId: 1,
   no: 1,
   name: "会社員としての基本姿勢",
   description: null,
-  eval_criteria: null,
+  evalCriteria: null,
   target: mockTarget,
   category: mockCategory,
 };
@@ -62,7 +62,7 @@ describe("GET /api/admin/evaluation-items", () => {
 describe("POST /api/admin/evaluation-items", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  const validBody = { target_id: 1, category_id: 1, name: "新しい評価項目" };
+  const validBody = { targetId: 1, categoryId: 1, name: "新しい評価項目" };
 
   it("admin は評価項目を追加でき、no が自動採番される", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
@@ -105,26 +105,26 @@ describe("POST /api/admin/evaluation-items", () => {
     );
   });
 
-  it("target_id が存在しない場合は 404", async () => {
+  it("targetId が存在しない場合は 404", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
     vi.mocked(prisma.target.findUnique).mockResolvedValue(null);
 
     const req = new Request("http://localhost/api/admin/evaluation-items", {
       method: "POST",
-      body: JSON.stringify({ ...validBody, target_id: 999 }),
+      body: JSON.stringify({ ...validBody, targetId: 999 }),
     });
     const res = await POST(req);
     expect(res.status).toBe(404);
   });
 
-  it("category_id が存在しない場合は 404", async () => {
+  it("categoryId が存在しない場合は 404", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
     vi.mocked(prisma.target.findUnique).mockResolvedValue(mockTarget as never);
     vi.mocked(prisma.category.findUnique).mockResolvedValue(null);
 
     const req = new Request("http://localhost/api/admin/evaluation-items", {
       method: "POST",
-      body: JSON.stringify({ ...validBody, category_id: 999 }),
+      body: JSON.stringify({ ...validBody, categoryId: 999 }),
     });
     const res = await POST(req);
     expect(res.status).toBe(404);
@@ -133,7 +133,7 @@ describe("POST /api/admin/evaluation-items", () => {
   it("category が target に属さない場合は 400", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
     vi.mocked(prisma.target.findUnique).mockResolvedValue(mockTarget as never);
-    vi.mocked(prisma.category.findUnique).mockResolvedValue({ ...mockCategory, target_id: 2 } as never);
+    vi.mocked(prisma.category.findUnique).mockResolvedValue({ ...mockCategory, targetId: 2 } as never);
 
     const req = new Request("http://localhost/api/admin/evaluation-items", {
       method: "POST",
@@ -143,12 +143,12 @@ describe("POST /api/admin/evaluation-items", () => {
     expect(res.status).toBe(400);
   });
 
-  it("target_id がない場合は 400", async () => {
+  it("targetId がない場合は 400", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
 
     const req = new Request("http://localhost/api/admin/evaluation-items", {
       method: "POST",
-      body: JSON.stringify({ category_id: 1, name: "test" }),
+      body: JSON.stringify({ categoryId: 1, name: "test" }),
     });
     const res = await POST(req);
     expect(res.status).toBe(400);
@@ -159,7 +159,7 @@ describe("POST /api/admin/evaluation-items", () => {
 
     const req = new Request("http://localhost/api/admin/evaluation-items", {
       method: "POST",
-      body: JSON.stringify({ target_id: 1, category_id: 1 }),
+      body: JSON.stringify({ targetId: 1, categoryId: 1 }),
     });
     const res = await POST(req);
     expect(res.status).toBe(400);

--- a/src/app/api/admin/evaluation-items/route.ts
+++ b/src/app/api/admin/evaluation-items/route.ts
@@ -5,14 +5,14 @@ import { prisma } from "@/lib/prisma";
 
 const itemSelect = {
   id: true,
-  target_id: true,
-  category_id: true,
+  targetId: true,
+  categoryId: true,
   no: true,
   name: true,
   description: true,
-  eval_criteria: true,
+  evalCriteria: true,
   target: { select: { id: true, name: true, no: true } },
-  category: { select: { id: true, target_id: true, name: true, no: true } },
+  category: { select: { id: true, targetId: true, name: true, no: true } },
 } as const;
 
 export async function GET() {
@@ -36,28 +36,28 @@ export async function POST(request: Request) {
   const body = await request.json().catch(() => null);
   if (
     !body ||
-    !Number.isInteger(body.target_id) ||
-    body.target_id < 1 ||
-    !Number.isInteger(body.category_id) ||
-    body.category_id < 1 ||
+    !Number.isInteger(body.targetId) ||
+    body.targetId < 1 ||
+    !Number.isInteger(body.categoryId) ||
+    body.categoryId < 1 ||
     typeof body.name !== "string" ||
     !body.name
   ) {
-    return errorResponse("BAD_REQUEST", "target_id, category_id, name は必須です", 400);
+    return errorResponse("BAD_REQUEST", "targetId, categoryId, name は必須です", 400);
   }
 
-  const target = await prisma.target.findUnique({ where: { id: body.target_id } });
+  const target = await prisma.target.findUnique({ where: { id: body.targetId } });
   if (!target) return errorResponse("NOT_FOUND", "大分類が見つかりません", 404);
 
-  const category = await prisma.category.findUnique({ where: { id: body.category_id } });
+  const category = await prisma.category.findUnique({ where: { id: body.categoryId } });
   if (!category) return errorResponse("NOT_FOUND", "中分類が見つかりません", 404);
 
-  if (category.target_id !== body.target_id) {
-    return errorResponse("BAD_REQUEST", "category_id が target_id と一致しません", 400);
+  if (category.targetId !== body.targetId) {
+    return errorResponse("BAD_REQUEST", "categoryId が targetId と一致しません", 400);
   }
 
   const maxItem = await prisma.evaluationItem.findFirst({
-    where: { category_id: body.category_id },
+    where: { categoryId: body.categoryId },
     orderBy: { no: "desc" },
     select: { no: true },
   });
@@ -65,12 +65,12 @@ export async function POST(request: Request) {
 
   const item = await prisma.evaluationItem.create({
     data: {
-      target_id: body.target_id,
-      category_id: body.category_id,
+      targetId: body.targetId,
+      categoryId: body.categoryId,
       no,
       name: body.name,
       description: typeof body.description === "string" ? body.description : null,
-      eval_criteria: typeof body.eval_criteria === "string" ? body.eval_criteria : null,
+      evalCriteria: typeof body.evalCriteria === "string" ? body.evalCriteria : null,
     },
     select: itemSelect,
   });

--- a/src/app/api/admin/fiscal-years/[year]/items/[itemId]/route.test.ts
+++ b/src/app/api/admin/fiscal-years/[year]/items/[itemId]/route.test.ts
@@ -14,7 +14,7 @@ import { prisma } from "@/lib/prisma";
 
 const adminSession = { user: { id: "admin-1", role: "admin" } };
 const memberSession = { user: { id: "member-1", role: "member" } };
-const mockItem = { fiscal_year: 2026, evaluation_item_id: 1 };
+const mockItem = { fiscalYear: 2026, evaluationItemId: 1 };
 
 function makeParams(year: string, itemId: string) {
   return { params: Promise.resolve({ year, itemId }) };

--- a/src/app/api/admin/fiscal-years/[year]/items/[itemId]/route.ts
+++ b/src/app/api/admin/fiscal-years/[year]/items/[itemId]/route.ts
@@ -20,12 +20,12 @@ export async function DELETE(_request: Request, { params }: Params) {
     return errorResponse("BAD_REQUEST", "itemId は正の整数で指定してください", 400);
 
   const existing = await prisma.fiscalYearItem.findUnique({
-    where: { fiscal_year_evaluation_item_id: { fiscal_year: year, evaluation_item_id: itemId } },
+    where: { fiscalYear_evaluationItemId: { fiscalYear: year, evaluationItemId: itemId } },
   });
   if (!existing) return errorResponse("NOT_FOUND", "紐づきが見つかりません", 404);
 
   await prisma.fiscalYearItem.delete({
-    where: { fiscal_year_evaluation_item_id: { fiscal_year: year, evaluation_item_id: itemId } },
+    where: { fiscalYear_evaluationItemId: { fiscalYear: year, evaluationItemId: itemId } },
   });
 
   return new Response(null, { status: 204 });

--- a/src/app/api/admin/fiscal-years/[year]/items/route.test.ts
+++ b/src/app/api/admin/fiscal-years/[year]/items/route.test.ts
@@ -18,8 +18,8 @@ const adminSession = { user: { id: "admin-1", role: "admin" } };
 const mockFy = { year: 2026 };
 const mockItem = {
   id: 1,
-  target_id: 1,
-  category_id: 1,
+  targetId: 1,
+  categoryId: 1,
   no: 1,
   name: "基本姿勢",
 };
@@ -35,7 +35,7 @@ describe("GET /api/admin/fiscal-years/:year/items", () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
     vi.mocked(prisma.fiscalYear.findUnique).mockResolvedValue(mockFy as never);
     vi.mocked(prisma.fiscalYearItem.findMany).mockResolvedValue([
-      { evaluation_item: mockItem },
+      { evaluationItem: mockItem },
     ] as never);
 
     const req = new Request("http://localhost/api/admin/fiscal-years/2026/items");
@@ -67,13 +67,13 @@ describe("POST /api/admin/fiscal-years/:year/items", () => {
     vi.mocked(prisma.evaluationItem.findUnique).mockResolvedValue(mockItem as never);
     vi.mocked(prisma.fiscalYearItem.findUnique).mockResolvedValue(null);
     vi.mocked(prisma.fiscalYearItem.create).mockResolvedValue({
-      fiscal_year: 2026,
-      evaluation_item_id: 1,
+      fiscalYear: 2026,
+      evaluationItemId: 1,
     } as never);
 
     const req = new Request("http://localhost/api/admin/fiscal-years/2026/items", {
       method: "POST",
-      body: JSON.stringify({ evaluation_item_id: 1 }),
+      body: JSON.stringify({ evaluationItemId: 1 }),
     });
     const res = await POST(req, makeParams("2026"));
     expect(res.status).toBe(201);
@@ -84,19 +84,19 @@ describe("POST /api/admin/fiscal-years/:year/items", () => {
     vi.mocked(prisma.fiscalYear.findUnique).mockResolvedValue(mockFy as never);
     vi.mocked(prisma.evaluationItem.findUnique).mockResolvedValue(mockItem as never);
     vi.mocked(prisma.fiscalYearItem.findUnique).mockResolvedValue({
-      fiscal_year: 2026,
-      evaluation_item_id: 1,
+      fiscalYear: 2026,
+      evaluationItemId: 1,
     } as never);
 
     const req = new Request("http://localhost/api/admin/fiscal-years/2026/items", {
       method: "POST",
-      body: JSON.stringify({ evaluation_item_id: 1 }),
+      body: JSON.stringify({ evaluationItemId: 1 }),
     });
     const res = await POST(req, makeParams("2026"));
     expect(res.status).toBe(409);
   });
 
-  it("evaluation_item_id が未指定の場合は 400", async () => {
+  it("evaluationItemId が未指定の場合は 400", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
 
     const req = new Request("http://localhost/api/admin/fiscal-years/2026/items", {

--- a/src/app/api/admin/fiscal-years/[year]/items/route.ts
+++ b/src/app/api/admin/fiscal-years/[year]/items/route.ts
@@ -19,22 +19,22 @@ export async function GET(_request: Request, { params }: Params) {
   if (!fiscalYear) return errorResponse("NOT_FOUND", "年度が見つかりません", 404);
 
   const items = await prisma.fiscalYearItem.findMany({
-    where: { fiscal_year: year },
+    where: { fiscalYear: year },
     include: {
-      evaluation_item: {
+      evaluationItem: {
         select: {
           id: true,
-          target_id: true,
-          category_id: true,
+          targetId: true,
+          categoryId: true,
           no: true,
           name: true,
         },
       },
     },
-    orderBy: { evaluation_item: { no: "asc" } },
+    orderBy: { evaluationItem: { no: "asc" } },
   });
 
-  return successResponse(items.map((i) => i.evaluation_item));
+  return successResponse(items.map((i) => i.evaluationItem));
 }
 
 export async function POST(request: Request, { params }: Params) {
@@ -48,29 +48,29 @@ export async function POST(request: Request, { params }: Params) {
     return errorResponse("BAD_REQUEST", "year は整数で指定してください", 400);
 
   const body = await request.json().catch(() => null);
-  if (!body || !Number.isInteger(body.evaluation_item_id) || body.evaluation_item_id < 1) {
-    return errorResponse("BAD_REQUEST", "evaluation_item_id は正の整数で指定してください", 400);
+  if (!body || !Number.isInteger(body.evaluationItemId) || body.evaluationItemId < 1) {
+    return errorResponse("BAD_REQUEST", "evaluationItemId は正の整数で指定してください", 400);
   }
 
   const fiscalYear = await prisma.fiscalYear.findUnique({ where: { year } });
   if (!fiscalYear) return errorResponse("NOT_FOUND", "年度が見つかりません", 404);
 
-  const item = await prisma.evaluationItem.findUnique({ where: { id: body.evaluation_item_id } });
+  const item = await prisma.evaluationItem.findUnique({ where: { id: body.evaluationItemId } });
   if (!item) return errorResponse("NOT_FOUND", "評価項目が見つかりません", 404);
 
   const existing = await prisma.fiscalYearItem.findUnique({
     where: {
-      fiscal_year_evaluation_item_id: {
-        fiscal_year: year,
-        evaluation_item_id: body.evaluation_item_id,
+      fiscalYear_evaluationItemId: {
+        fiscalYear: year,
+        evaluationItemId: body.evaluationItemId,
       },
     },
   });
   if (existing) return errorResponse("CONFLICT", "すでに紐づいています", 409);
 
   const created = await prisma.fiscalYearItem.create({
-    data: { fiscal_year: year, evaluation_item_id: body.evaluation_item_id },
-    select: { fiscal_year: true, evaluation_item_id: true },
+    data: { fiscalYear: year, evaluationItemId: body.evaluationItemId },
+    select: { fiscalYear: true, evaluationItemId: true },
   });
 
   return successResponse(created, undefined, 201);

--- a/src/app/api/admin/fiscal-years/[year]/route.test.ts
+++ b/src/app/api/admin/fiscal-years/[year]/route.test.ts
@@ -22,9 +22,9 @@ const memberSession = { user: { id: "member-1", role: "member" } };
 const mockFy = {
   year: 2026,
   name: "2026年度",
-  start_date: new Date("2026-04-01"),
-  end_date: new Date("2027-03-31"),
-  is_current: false,
+  startDate: new Date("2026-04-01"),
+  endDate: new Date("2027-03-31"),
+  isCurrent: false,
 };
 
 function makeParams(year: string) {
@@ -52,22 +52,22 @@ describe("PATCH /api/admin/fiscal-years/:year", () => {
     expect(res.status).toBe(200);
   });
 
-  it("is_current: true にすると他年度が false になる", async () => {
+  it("isCurrent: true にすると他年度が false になる", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
     vi.mocked(prisma.fiscalYear.findUnique).mockResolvedValue(mockFy as never);
     vi.mocked(prisma.$transaction).mockImplementation(async (fn) => fn(prisma as never));
     vi.mocked(prisma.fiscalYear.updateMany).mockResolvedValue({ count: 1 } as never);
-    vi.mocked(prisma.fiscalYear.update).mockResolvedValue({ ...mockFy, is_current: true } as never);
+    vi.mocked(prisma.fiscalYear.update).mockResolvedValue({ ...mockFy, isCurrent: true } as never);
 
     const req = new Request("http://localhost/api/admin/fiscal-years/2026", {
       method: "PATCH",
-      body: JSON.stringify({ is_current: true }),
+      body: JSON.stringify({ isCurrent: true }),
     });
     const res = await PATCH(req, makeParams("2026"));
     expect(res.status).toBe(200);
     expect(prisma.fiscalYear.updateMany).toHaveBeenCalledWith({
-      where: { is_current: true, year: { not: 2026 } },
-      data: { is_current: false },
+      where: { isCurrent: true, year: { not: 2026 } },
+      data: { isCurrent: false },
     });
   });
 
@@ -109,31 +109,31 @@ describe("PATCH /api/admin/fiscal-years/:year", () => {
 
     const req = new Request("http://localhost/api/admin/fiscal-years/2026", {
       method: "PATCH",
-      body: JSON.stringify({ start_date: 123, end_date: 456 }),
+      body: JSON.stringify({ startDate: 123, endDate: 456 }),
     });
     const res = await PATCH(req, makeParams("2026"));
     expect(res.status).toBe(400);
   });
 
-  it("start_date が不正な日付文字列の場合は 400", async () => {
+  it("startDate が不正な日付文字列の場合は 400", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
     vi.mocked(prisma.fiscalYear.findUnique).mockResolvedValue(mockFy as never);
 
     const req = new Request("http://localhost/api/admin/fiscal-years/2026", {
       method: "PATCH",
-      body: JSON.stringify({ start_date: "not-a-date" }),
+      body: JSON.stringify({ startDate: "not-a-date" }),
     });
     const res = await PATCH(req, makeParams("2026"));
     expect(res.status).toBe(400);
   });
 
-  it("start_date が end_date より後の場合は 400", async () => {
+  it("startDate が endDate より後の場合は 400", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
     vi.mocked(prisma.fiscalYear.findUnique).mockResolvedValue(mockFy as never);
 
     const req = new Request("http://localhost/api/admin/fiscal-years/2026", {
       method: "PATCH",
-      body: JSON.stringify({ start_date: "2028-01-01" }),
+      body: JSON.stringify({ startDate: "2028-01-01" }),
     });
     const res = await PATCH(req, makeParams("2026"));
     expect(res.status).toBe(400);

--- a/src/app/api/admin/fiscal-years/[year]/route.ts
+++ b/src/app/api/admin/fiscal-years/[year]/route.ts
@@ -23,41 +23,41 @@ export async function PATCH(request: Request, { params }: Params) {
 
   const data: {
     name?: string;
-    start_date?: Date;
-    end_date?: Date;
-    is_current?: boolean;
+    startDate?: Date;
+    endDate?: Date;
+    isCurrent?: boolean;
   } = {};
   if (typeof body.name === "string") data.name = body.name;
-  if (typeof body.start_date === "string") data.start_date = new Date(body.start_date);
-  if (typeof body.end_date === "string") data.end_date = new Date(body.end_date);
-  if (typeof body.is_current === "boolean") data.is_current = body.is_current;
+  if (typeof body.startDate === "string") data.startDate = new Date(body.startDate);
+  if (typeof body.endDate === "string") data.endDate = new Date(body.endDate);
+  if (typeof body.isCurrent === "boolean") data.isCurrent = body.isCurrent;
 
   if (Object.keys(data).length === 0)
     return errorResponse("BAD_REQUEST", "更新可能なフィールドが指定されていません", 400);
 
-  if (data.start_date && Number.isNaN(data.start_date.getTime()))
-    return errorResponse("BAD_REQUEST", "start_date は有効な日付形式で指定してください", 400);
-  if (data.end_date && Number.isNaN(data.end_date.getTime()))
-    return errorResponse("BAD_REQUEST", "end_date は有効な日付形式で指定してください", 400);
+  if (data.startDate && Number.isNaN(data.startDate.getTime()))
+    return errorResponse("BAD_REQUEST", "startDate は有効な日付形式で指定してください", 400);
+  if (data.endDate && Number.isNaN(data.endDate.getTime()))
+    return errorResponse("BAD_REQUEST", "endDate は有効な日付形式で指定してください", 400);
 
   // 両方指定された場合、または片方が指定されてもう一方が既存値から取れる場合の整合性チェック
-  const effectiveStart = data.start_date ?? target.start_date;
-  const effectiveEnd = data.end_date ?? target.end_date;
+  const effectiveStart = data.startDate ?? target.startDate;
+  const effectiveEnd = data.endDate ?? target.endDate;
   if (effectiveStart > effectiveEnd)
-    return errorResponse("BAD_REQUEST", "start_date は end_date 以前の日付を指定してください", 400);
+    return errorResponse("BAD_REQUEST", "startDate は endDate 以前の日付を指定してください", 400);
 
   const updated = await prisma.$transaction(async (tx) => {
-    // is_current: true にする場合、他の年度を false に
-    if (data.is_current === true) {
+    // isCurrent: true にする場合、他の年度を false に
+    if (data.isCurrent === true) {
       await tx.fiscalYear.updateMany({
-        where: { is_current: true, year: { not: year } },
-        data: { is_current: false },
+        where: { isCurrent: true, year: { not: year } },
+        data: { isCurrent: false },
       });
     }
     return tx.fiscalYear.update({
       where: { year },
       data,
-      select: { year: true, name: true, start_date: true, end_date: true, is_current: true },
+      select: { year: true, name: true, startDate: true, endDate: true, isCurrent: true },
     });
   });
 
@@ -78,10 +78,10 @@ export async function DELETE(_request: Request, { params }: Params) {
   if (!target) return errorResponse("NOT_FOUND", "年度が見つかりません", 404);
 
   const [assignmentCount, evaluationCount, settingCount, itemCount] = await Promise.all([
-    prisma.evaluationAssignment.count({ where: { fiscal_year: year } }),
-    prisma.evaluation.count({ where: { fiscal_year: year } }),
-    prisma.evaluationSetting.count({ where: { fiscal_year: year } }),
-    prisma.fiscalYearItem.count({ where: { fiscal_year: year } }),
+    prisma.evaluationAssignment.count({ where: { fiscalYear: year } }),
+    prisma.evaluation.count({ where: { fiscalYear: year } }),
+    prisma.evaluationSetting.count({ where: { fiscalYear: year } }),
+    prisma.fiscalYearItem.count({ where: { fiscalYear: year } }),
   ]);
 
   if (assignmentCount > 0 || evaluationCount > 0 || settingCount > 0 || itemCount > 0) {

--- a/src/app/api/admin/fiscal-years/route.test.ts
+++ b/src/app/api/admin/fiscal-years/route.test.ts
@@ -21,16 +21,16 @@ const mockFiscalYears = [
   {
     year: 2026,
     name: "2026年度",
-    start_date: new Date("2026-04-01"),
-    end_date: new Date("2027-03-31"),
-    is_current: true,
+    startDate: new Date("2026-04-01"),
+    endDate: new Date("2027-03-31"),
+    isCurrent: true,
   },
   {
     year: 2025,
     name: "2025年度",
-    start_date: new Date("2025-04-01"),
-    end_date: new Date("2026-03-31"),
-    is_current: false,
+    startDate: new Date("2025-04-01"),
+    endDate: new Date("2026-03-31"),
+    isCurrent: false,
   },
 ];
 
@@ -71,9 +71,9 @@ describe("POST /api/admin/fiscal-years", () => {
     const newFy = {
       year: 2028,
       name: "2028年度",
-      start_date: new Date("2028-04-01"),
-      end_date: new Date("2029-03-31"),
-      is_current: false,
+      startDate: new Date("2028-04-01"),
+      endDate: new Date("2029-03-31"),
+      isCurrent: false,
     };
     vi.mocked(prisma.$transaction).mockImplementation(async (fn) => fn(prisma as never));
     vi.mocked(prisma.fiscalYear.create).mockResolvedValue(newFy as never);
@@ -84,8 +84,8 @@ describe("POST /api/admin/fiscal-years", () => {
       body: JSON.stringify({
         year: 2028,
         name: "2028年度",
-        start_date: "2028-04-01",
-        end_date: "2029-03-31",
+        startDate: "2028-04-01",
+        endDate: "2029-03-31",
       }),
     });
     const res = await POST(req);
@@ -104,8 +104,8 @@ describe("POST /api/admin/fiscal-years", () => {
       body: JSON.stringify({
         year: 2026,
         name: "2026年度",
-        start_date: "2026-04-01",
-        end_date: "2027-03-31",
+        startDate: "2026-04-01",
+        endDate: "2027-03-31",
       }),
     });
     const res = await POST(req);
@@ -128,7 +128,7 @@ describe("POST /api/admin/fiscal-years", () => {
 
     const req = new Request("http://localhost/api/admin/fiscal-years", {
       method: "POST",
-      body: JSON.stringify({ year: 2028.5, name: "2028年度", start_date: "2028-04-01", end_date: "2029-03-31" }),
+      body: JSON.stringify({ year: 2028.5, name: "2028年度", startDate: "2028-04-01", endDate: "2029-03-31" }),
     });
     const res = await POST(req);
     expect(res.status).toBe(400);
@@ -139,29 +139,29 @@ describe("POST /api/admin/fiscal-years", () => {
 
     const req = new Request("http://localhost/api/admin/fiscal-years", {
       method: "POST",
-      body: JSON.stringify({ year: 1800, name: "1800年度", start_date: "1800-04-01", end_date: "1801-03-31" }),
+      body: JSON.stringify({ year: 1800, name: "1800年度", startDate: "1800-04-01", endDate: "1801-03-31" }),
     });
     const res = await POST(req);
     expect(res.status).toBe(400);
   });
 
-  it("start_date が不正な日付文字列の場合は 400", async () => {
+  it("startDate が不正な日付文字列の場合は 400", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
 
     const req = new Request("http://localhost/api/admin/fiscal-years", {
       method: "POST",
-      body: JSON.stringify({ year: 2028, name: "2028年度", start_date: "not-a-date", end_date: "2029-03-31" }),
+      body: JSON.stringify({ year: 2028, name: "2028年度", startDate: "not-a-date", endDate: "2029-03-31" }),
     });
     const res = await POST(req);
     expect(res.status).toBe(400);
   });
 
-  it("start_date が end_date より後の場合は 400", async () => {
+  it("startDate が endDate より後の場合は 400", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
 
     const req = new Request("http://localhost/api/admin/fiscal-years", {
       method: "POST",
-      body: JSON.stringify({ year: 2028, name: "2028年度", start_date: "2029-03-31", end_date: "2028-04-01" }),
+      body: JSON.stringify({ year: 2028, name: "2028年度", startDate: "2029-03-31", endDate: "2028-04-01" }),
     });
     const res = await POST(req);
     expect(res.status).toBe(400);
@@ -174,15 +174,15 @@ describe("POST /api/admin/fiscal-years", () => {
     const newFy = {
       year: 2027,
       name: "2027年度",
-      start_date: new Date("2027-04-01"),
-      end_date: new Date("2028-03-31"),
-      is_current: false,
+      startDate: new Date("2027-04-01"),
+      endDate: new Date("2028-03-31"),
+      isCurrent: false,
     };
     vi.mocked(prisma.$transaction).mockImplementation(async (fn) => fn(prisma as never));
     vi.mocked(prisma.fiscalYear.create).mockResolvedValue(newFy as never);
     vi.mocked(prisma.fiscalYearItem.findMany).mockResolvedValue([
-      { evaluation_item_id: 1 },
-      { evaluation_item_id: 2 },
+      { evaluationItemId: 1 },
+      { evaluationItemId: 2 },
     ] as never);
     vi.mocked(prisma.fiscalYearItem.createMany).mockResolvedValue({ count: 2 } as never);
 
@@ -191,16 +191,16 @@ describe("POST /api/admin/fiscal-years", () => {
       body: JSON.stringify({
         year: 2027,
         name: "2027年度",
-        start_date: "2027-04-01",
-        end_date: "2028-03-31",
+        startDate: "2027-04-01",
+        endDate: "2028-03-31",
       }),
     });
     const res = await POST(req);
     expect(res.status).toBe(201);
     expect(prisma.fiscalYearItem.createMany).toHaveBeenCalledWith({
       data: [
-        { fiscal_year: 2027, evaluation_item_id: 1 },
-        { fiscal_year: 2027, evaluation_item_id: 2 },
+        { fiscalYear: 2027, evaluationItemId: 1 },
+        { fiscalYear: 2027, evaluationItemId: 2 },
       ],
     });
   });

--- a/src/app/api/admin/fiscal-years/route.ts
+++ b/src/app/api/admin/fiscal-years/route.ts
@@ -10,7 +10,7 @@ export async function GET() {
 
   const fiscalYears = await prisma.fiscalYear.findMany({
     orderBy: { year: "desc" },
-    select: { year: true, name: true, start_date: true, end_date: true, is_current: true },
+    select: { year: true, name: true, startDate: true, endDate: true, isCurrent: true },
   });
 
   return successResponse(fiscalYears);
@@ -28,19 +28,19 @@ export async function POST(request: Request) {
     body.year < 1900 ||
     body.year > 9999 ||
     typeof body.name !== "string" ||
-    typeof body.start_date !== "string" ||
-    typeof body.end_date !== "string"
+    typeof body.startDate !== "string" ||
+    typeof body.endDate !== "string"
   ) {
-    return errorResponse("BAD_REQUEST", "year, name, start_date, end_date は必須です", 400);
+    return errorResponse("BAD_REQUEST", "year, name, startDate, endDate は必須です", 400);
   }
 
-  const startDate = new Date(body.start_date);
-  const endDate = new Date(body.end_date);
+  const startDate = new Date(body.startDate);
+  const endDate = new Date(body.endDate);
   if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
-    return errorResponse("BAD_REQUEST", "start_date, end_date は有効な日付形式で指定してください", 400);
+    return errorResponse("BAD_REQUEST", "startDate, endDate は有効な日付形式で指定してください", 400);
   }
   if (startDate > endDate) {
-    return errorResponse("BAD_REQUEST", "start_date は end_date 以前の日付を指定してください", 400);
+    return errorResponse("BAD_REQUEST", "startDate は endDate 以前の日付を指定してください", 400);
   }
 
   const existing = await prisma.fiscalYear.findUnique({ where: { year: body.year } });
@@ -58,22 +58,22 @@ export async function POST(request: Request) {
       data: {
         year: body.year,
         name: body.name,
-        start_date: startDate,
-        end_date: endDate,
+        startDate: startDate,
+        endDate: endDate,
       },
-      select: { year: true, name: true, start_date: true, end_date: true, is_current: true },
+      select: { year: true, name: true, startDate: true, endDate: true, isCurrent: true },
     });
 
     if (latestFy) {
       const sourceItems = await tx.fiscalYearItem.findMany({
-        where: { fiscal_year: latestFy.year },
-        select: { evaluation_item_id: true },
+        where: { fiscalYear: latestFy.year },
+        select: { evaluationItemId: true },
       });
       if (sourceItems.length > 0) {
         await tx.fiscalYearItem.createMany({
           data: sourceItems.map((item) => ({
-            fiscal_year: body.year,
-            evaluation_item_id: item.evaluation_item_id,
+            fiscalYear: body.year,
+            evaluationItemId: item.evaluationItemId,
           })),
         });
       }

--- a/src/app/api/admin/targets/[id]/route.ts
+++ b/src/app/api/admin/targets/[id]/route.ts
@@ -53,7 +53,7 @@ export async function DELETE(_request: Request, { params }: Params) {
   const target = await prisma.target.findUnique({ where: { id } });
   if (!target) return errorResponse("NOT_FOUND", "大分類が見つかりません", 404);
 
-  const categoryCount = await prisma.category.count({ where: { target_id: id } });
+  const categoryCount = await prisma.category.count({ where: { targetId: id } });
   if (categoryCount > 0) return errorResponse("CONFLICT", "紐づく中分類が存在するため削除できません", 409);
 
   await prisma.target.delete({ where: { id } });

--- a/src/app/api/admin/users/[id]/route.test.ts
+++ b/src/app/api/admin/users/[id]/route.test.ts
@@ -55,17 +55,17 @@ describe("PATCH /api/admin/users/[id]", () => {
   it("admin はユーザーを無効化できる", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
     vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as never);
-    vi.mocked(prisma.user.update).mockResolvedValue({ ...mockUser, is_active: false } as never);
+    vi.mocked(prisma.user.update).mockResolvedValue({ ...mockUser, isActive: false } as never);
 
     const req = new Request("http://localhost/api/admin/users/user-2", {
       method: "PATCH",
-      body: JSON.stringify({ is_active: false }),
+      body: JSON.stringify({ isActive: false }),
     });
     const res = await PATCH(req, makeParams("user-2"));
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body.data.is_active).toBe(false);
+    expect(body.data.isActive).toBe(false);
   });
 
   it("自分自身のロールは変更できない（403）", async () => {
@@ -80,7 +80,7 @@ describe("PATCH /api/admin/users/[id]", () => {
     expect(res.status).toBe(403);
   });
 
-  it("role も is_active も指定しない場合は 400 を返す", async () => {
+  it("role も isActive も指定しない場合は 400 を返す", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
 
     const req = new Request("http://localhost/api/admin/users/user-2", {

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -23,11 +23,11 @@ export async function PATCH(
 
   const body = await request.json().catch(() => null);
   const validRole = body?.role === "admin" || body?.role === "member";
-  const validIsActive = body?.is_active === true || body?.is_active === false;
+  const validIsActive = body?.isActive === true || body?.isActive === false;
   if (!body || (!validRole && !validIsActive)) {
     return errorResponse(
       "BAD_REQUEST",
-      "role は 'admin' または 'member'、is_active は true または false で指定してください",
+      "role は 'admin' または 'member'、isActive は true または false で指定してください",
       400,
     );
   }
@@ -37,14 +37,14 @@ export async function PATCH(
     return errorResponse("NOT_FOUND", "ユーザーが見つかりません", 404);
   }
 
-  const data: { role?: "admin" | "member"; is_active?: boolean } = {};
+  const data: { role?: "admin" | "member"; isActive?: boolean } = {};
   if (validRole) data.role = body.role;
-  if (validIsActive) data.is_active = body.is_active;
+  if (validIsActive) data.isActive = body.isActive;
 
   const updated = await prisma.user.update({
     where: { id },
     data,
-    select: { id: true, name: true, email: true, role: true, is_active: true },
+    select: { id: true, name: true, email: true, role: true, isActive: true },
   });
 
   return successResponse(updated);
@@ -76,10 +76,10 @@ export async function DELETE(
   // 関連データが存在する場合は削除不可
   const [assignmentCount, evaluationCount, settingCount] = await Promise.all([
     prisma.evaluationAssignment.count({
-      where: { OR: [{ evaluatee_id: id }, { evaluator_id: id }] },
+      where: { OR: [{ evaluateeId: id }, { evaluatorId: id }] },
     }),
-    prisma.evaluation.count({ where: { evaluatee_id: id } }),
-    prisma.evaluationSetting.count({ where: { user_id: id } }),
+    prisma.evaluation.count({ where: { evaluateeId: id } }),
+    prisma.evaluationSetting.count({ where: { userId: id } }),
   ]);
 
   if (assignmentCount > 0 || evaluationCount > 0 || settingCount > 0) {

--- a/src/app/api/admin/users/route.test.ts
+++ b/src/app/api/admin/users/route.test.ts
@@ -22,8 +22,8 @@ const mockUsers = [
     email: "tanaka@example.com",
     role: "admin",
     division: "開発部",
-    joined_at: null,
-    created_at: new Date("2025-01-01"),
+    joinedAt: null,
+    createdAt: new Date("2025-01-01"),
   },
   {
     id: "user-2",
@@ -31,8 +31,8 @@ const mockUsers = [
     email: "suzuki@example.com",
     role: "member",
     division: null,
-    joined_at: null,
-    created_at: new Date("2025-02-01"),
+    joinedAt: null,
+    createdAt: new Date("2025-02-01"),
   },
 ];
 

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -19,9 +19,9 @@ export async function GET() {
       email: true,
       role: true,
       division: true,
-      joined_at: true,
-      created_at: true,
-      is_active: true,
+      joinedAt: true,
+      createdAt: true,
+      isActive: true,
     },
     orderBy: { name: "asc" },
   });

--- a/src/app/api/evaluation-assignments/[id]/route.test.ts
+++ b/src/app/api/evaluation-assignments/[id]/route.test.ts
@@ -20,9 +20,9 @@ const memberSession = { user: { id: "member-1", role: "member" } };
 
 const mockAssignment = {
   id: "assign-1",
-  fiscal_year: 2025,
-  evaluatee_id: "user-2",
-  evaluator_id: "user-1",
+  fiscalYear: 2025,
+  evaluateeId: "user-2",
+  evaluatorId: "user-1",
 };
 
 const makeParams = (id: string) => Promise.resolve({ id });

--- a/src/app/api/evaluation-assignments/route.test.ts
+++ b/src/app/api/evaluation-assignments/route.test.ts
@@ -22,9 +22,9 @@ const memberSession = { user: { id: "member-1", role: "member" } };
 const mockAssignments = [
   {
     id: "assign-1",
-    fiscal_year: 2025,
-    evaluatee_id: "user-2",
-    evaluator_id: "user-1",
+    fiscalYear: 2025,
+    evaluateeId: "user-2",
+    evaluatorId: "user-1",
     evaluatee: { id: "user-2", name: "鈴木花子" },
     evaluator: { id: "user-1", name: "田中太郎" },
   },
@@ -43,25 +43,25 @@ describe("GET /api/evaluation-assignments", () => {
 
     expect(res.status).toBe(200);
     expect(body.data).toHaveLength(1);
-    expect(body.data[0]).toMatchObject({ id: "assign-1", fiscal_year: 2025 });
+    expect(body.data[0]).toMatchObject({ id: "assign-1", fiscalYear: 2025 });
   });
 
-  it("fiscal_year クエリで絞り込みができる", async () => {
+  it("fiscalYear クエリで絞り込みができる", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
     vi.mocked(prisma.evaluationAssignment.findMany).mockResolvedValue(mockAssignments);
 
-    const req = new Request("http://localhost/api/evaluation-assignments?fiscal_year=2025");
+    const req = new Request("http://localhost/api/evaluation-assignments?fiscalYear=2025");
     await GET(req);
 
     expect(prisma.evaluationAssignment.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { fiscal_year: 2025 } }),
+      expect.objectContaining({ where: { fiscalYear: 2025 } }),
     );
   });
 
-  it("fiscal_year が数値以外の場合は 400 を返す", async () => {
+  it("fiscalYear が数値以外の場合は 400 を返す", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
 
-    const req = new Request("http://localhost/api/evaluation-assignments?fiscal_year=abc");
+    const req = new Request("http://localhost/api/evaluation-assignments?fiscalYear=abc");
     const res = await GET(req);
 
     expect(res.status).toBe(400);
@@ -94,20 +94,20 @@ describe("POST /api/evaluation-assignments", () => {
     vi.mocked(prisma.evaluationAssignment.findUnique).mockResolvedValue(null);
     vi.mocked(prisma.evaluationAssignment.create).mockResolvedValue({
       id: "assign-new",
-      fiscal_year: 2025,
-      evaluatee_id: "user-2",
-      evaluator_id: "user-1",
+      fiscalYear: 2025,
+      evaluateeId: "user-2",
+      evaluatorId: "user-1",
     });
 
     const req = new Request("http://localhost/api/evaluation-assignments", {
       method: "POST",
-      body: JSON.stringify({ fiscal_year: 2025, evaluatee_id: "user-2", evaluator_id: "user-1" }),
+      body: JSON.stringify({ fiscalYear: 2025, evaluateeId: "user-2", evaluatorId: "user-1" }),
     });
     const res = await POST(req);
     const body = await res.json();
 
     expect(res.status).toBe(201);
-    expect(body.data).toMatchObject({ fiscal_year: 2025 });
+    expect(body.data).toMatchObject({ fiscalYear: 2025 });
   });
 
   it("必須項目が欠けている場合は 400 を返す", async () => {
@@ -115,7 +115,7 @@ describe("POST /api/evaluation-assignments", () => {
 
     const req = new Request("http://localhost/api/evaluation-assignments", {
       method: "POST",
-      body: JSON.stringify({ fiscal_year: 2025 }),
+      body: JSON.stringify({ fiscalYear: 2025 }),
     });
     const res = await POST(req);
 
@@ -128,7 +128,7 @@ describe("POST /api/evaluation-assignments", () => {
 
     const req = new Request("http://localhost/api/evaluation-assignments", {
       method: "POST",
-      body: JSON.stringify({ fiscal_year: 2025, evaluatee_id: "user-2", evaluator_id: "user-1" }),
+      body: JSON.stringify({ fiscalYear: 2025, evaluateeId: "user-2", evaluatorId: "user-1" }),
     });
     const res = await POST(req);
 
@@ -140,7 +140,7 @@ describe("POST /api/evaluation-assignments", () => {
 
     const req = new Request("http://localhost/api/evaluation-assignments", {
       method: "POST",
-      body: JSON.stringify({ fiscal_year: 2025, evaluatee_id: "user-2", evaluator_id: "user-1" }),
+      body: JSON.stringify({ fiscalYear: 2025, evaluateeId: "user-2", evaluatorId: "user-1" }),
     });
     const res = await POST(req);
 
@@ -152,7 +152,7 @@ describe("POST /api/evaluation-assignments", () => {
 
     const req = new Request("http://localhost/api/evaluation-assignments", {
       method: "POST",
-      body: JSON.stringify({ fiscal_year: 2025, evaluatee_id: "user-2", evaluator_id: "user-1" }),
+      body: JSON.stringify({ fiscalYear: 2025, evaluateeId: "user-2", evaluatorId: "user-1" }),
     });
     const res = await POST(req);
 

--- a/src/app/api/evaluation-assignments/route.ts
+++ b/src/app/api/evaluation-assignments/route.ts
@@ -12,26 +12,26 @@ export async function GET(request: Request) {
   }
 
   const { searchParams } = new URL(request.url);
-  const fiscalYearParam = searchParams.get("fiscal_year");
+  const fiscalYearParam = searchParams.get("fiscalYear");
   const fiscalYear = fiscalYearParam ? Number(fiscalYearParam) : undefined;
 
   if (fiscalYearParam && Number.isNaN(fiscalYear)) {
-    return errorResponse("BAD_REQUEST", "fiscal_year は数値で指定してください", 400);
+    return errorResponse("BAD_REQUEST", "fiscalYear は数値で指定してください", 400);
   }
 
   const assignments = await prisma.evaluationAssignment.findMany({
-    where: fiscalYear ? { fiscal_year: fiscalYear } : undefined,
+    where: fiscalYear ? { fiscalYear: fiscalYear } : undefined,
     include: {
       evaluatee: { select: { id: true, name: true } },
       evaluator: { select: { id: true, name: true } },
     },
-    orderBy: [{ fiscal_year: "desc" }, { evaluatee_id: "asc" }],
+    orderBy: [{ fiscalYear: "desc" }, { evaluateeId: "asc" }],
   });
 
   return successResponse(
     assignments.map((a) => ({
       id: a.id,
-      fiscal_year: a.fiscal_year,
+      fiscalYear: a.fiscalYear,
       evaluatee: a.evaluatee,
       evaluator: a.evaluator,
     })),
@@ -50,19 +50,19 @@ export async function POST(request: Request) {
   const body = await request.json().catch(() => null);
   if (
     !body ||
-    typeof body.fiscal_year !== "number" ||
-    typeof body.evaluatee_id !== "string" ||
-    typeof body.evaluator_id !== "string"
+    typeof body.fiscalYear !== "number" ||
+    typeof body.evaluateeId !== "string" ||
+    typeof body.evaluatorId !== "string"
   ) {
-    return errorResponse("BAD_REQUEST", "fiscal_year, evaluatee_id, evaluator_id は必須です", 400);
+    return errorResponse("BAD_REQUEST", "fiscalYear, evaluateeId, evaluatorId は必須です", 400);
   }
 
   const existing = await prisma.evaluationAssignment.findUnique({
     where: {
-      fiscal_year_evaluatee_id_evaluator_id: {
-        fiscal_year: body.fiscal_year,
-        evaluatee_id: body.evaluatee_id,
-        evaluator_id: body.evaluator_id,
+      fiscalYear_evaluateeId_evaluatorId: {
+        fiscalYear: body.fiscalYear,
+        evaluateeId: body.evaluateeId,
+        evaluatorId: body.evaluatorId,
       },
     },
   });
@@ -72,9 +72,9 @@ export async function POST(request: Request) {
 
   const assignment = await prisma.evaluationAssignment.create({
     data: {
-      fiscal_year: body.fiscal_year,
-      evaluatee_id: body.evaluatee_id,
-      evaluator_id: body.evaluator_id,
+      fiscalYear: body.fiscalYear,
+      evaluateeId: body.evaluateeId,
+      evaluatorId: body.evaluatorId,
     },
   });
 

--- a/src/app/api/evaluation-items/route.test.ts
+++ b/src/app/api/evaluation-items/route.test.ts
@@ -13,27 +13,27 @@ import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 
 const mockTarget = { id: 1, name: "employee", no: 1 };
-const mockCategory = { id: 1, target_id: 1, name: "engagement", no: 1 };
+const mockCategory = { id: 1, targetId: 1, name: "engagement", no: 1 };
 const mockItems = [
   {
     id: 1,
-    target_id: 1,
-    category_id: 1,
+    targetId: 1,
+    categoryId: 1,
     no: 1,
     name: "会社員としての基本姿勢",
     description: "説明",
-    eval_criteria: "基準",
+    evalCriteria: "基準",
     target: mockTarget,
     category: mockCategory,
   },
   {
     id: 2,
-    target_id: 1,
-    category_id: 1,
+    targetId: 1,
+    categoryId: 1,
     no: 2,
     name: "積極性",
     description: null,
-    eval_criteria: null,
+    evalCriteria: null,
     target: mockTarget,
     category: mockCategory,
   },
@@ -58,13 +58,13 @@ describe("GET /api/evaluation-items", () => {
     vi.mocked(getSession).mockResolvedValue({ user: { id: "user-1", role: "member" } } as never);
     vi.mocked(prisma.evaluationItem.findMany).mockResolvedValue([mockItems[0]] as never);
 
-    const req = new Request("http://localhost/api/evaluation-items?target_id=1");
+    const req = new Request("http://localhost/api/evaluation-items?targetId=1");
     const res = await GET(req);
 
     expect(res.status).toBe(200);
     expect(prisma.evaluationItem.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ target_id: 1 }),
+        where: expect.objectContaining({ targetId: 1 }),
       }),
     );
   });
@@ -73,26 +73,26 @@ describe("GET /api/evaluation-items", () => {
     vi.mocked(getSession).mockResolvedValue({ user: { id: "user-1", role: "member" } } as never);
     vi.mocked(prisma.evaluationItem.findMany).mockResolvedValue(mockItems as never);
 
-    const req = new Request("http://localhost/api/evaluation-items?category_id=1");
+    const req = new Request("http://localhost/api/evaluation-items?categoryId=1");
     const res = await GET(req);
 
     expect(res.status).toBe(200);
     expect(prisma.evaluationItem.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ category_id: 1 }),
+        where: expect.objectContaining({ categoryId: 1 }),
       }),
     );
   });
 
   it("?target_id が不正値の場合は 400", async () => {
     vi.mocked(getSession).mockResolvedValue({ user: { id: "user-1", role: "member" } } as never);
-    const res = await GET(new Request("http://localhost/api/evaluation-items?target_id=abc"));
+    const res = await GET(new Request("http://localhost/api/evaluation-items?targetId=abc"));
     expect(res.status).toBe(400);
   });
 
   it("?category_id が不正値の場合は 400", async () => {
     vi.mocked(getSession).mockResolvedValue({ user: { id: "user-1", role: "member" } } as never);
-    const res = await GET(new Request("http://localhost/api/evaluation-items?category_id=abc"));
+    const res = await GET(new Request("http://localhost/api/evaluation-items?categoryId=abc"));
     expect(res.status).toBe(400);
   });
 

--- a/src/app/api/evaluation-items/route.test.ts
+++ b/src/app/api/evaluation-items/route.test.ts
@@ -54,7 +54,7 @@ describe("GET /api/evaluation-items", () => {
     expect(body.data).toHaveLength(2);
   });
 
-  it("?target_id でフィルタできる", async () => {
+  it("?targetId でフィルタできる", async () => {
     vi.mocked(getSession).mockResolvedValue({ user: { id: "user-1", role: "member" } } as never);
     vi.mocked(prisma.evaluationItem.findMany).mockResolvedValue([mockItems[0]] as never);
 
@@ -69,7 +69,7 @@ describe("GET /api/evaluation-items", () => {
     );
   });
 
-  it("?category_id でフィルタできる", async () => {
+  it("?categoryId でフィルタできる", async () => {
     vi.mocked(getSession).mockResolvedValue({ user: { id: "user-1", role: "member" } } as never);
     vi.mocked(prisma.evaluationItem.findMany).mockResolvedValue(mockItems as never);
 
@@ -84,13 +84,13 @@ describe("GET /api/evaluation-items", () => {
     );
   });
 
-  it("?target_id が不正値の場合は 400", async () => {
+  it("?targetId が不正値の場合は 400", async () => {
     vi.mocked(getSession).mockResolvedValue({ user: { id: "user-1", role: "member" } } as never);
     const res = await GET(new Request("http://localhost/api/evaluation-items?targetId=abc"));
     expect(res.status).toBe(400);
   });
 
-  it("?category_id が不正値の場合は 400", async () => {
+  it("?categoryId が不正値の場合は 400", async () => {
     vi.mocked(getSession).mockResolvedValue({ user: { id: "user-1", role: "member" } } as never);
     const res = await GET(new Request("http://localhost/api/evaluation-items?categoryId=abc"));
     expect(res.status).toBe(400);

--- a/src/app/api/evaluation-items/route.ts
+++ b/src/app/api/evaluation-items/route.ts
@@ -8,23 +8,23 @@ export async function GET(request: Request) {
   if (!session) return errorResponse("UNAUTHORIZED", "認証が必要です", 401);
 
   const { searchParams } = new URL(request.url);
-  const targetIdStr = searchParams.get("target_id");
-  const categoryIdStr = searchParams.get("category_id");
+  const targetIdStr = searchParams.get("targetId");
+  const categoryIdStr = searchParams.get("categoryId");
 
-  const where: { target_id?: number; category_id?: number } = {};
+  const where: { targetId?: number; categoryId?: number } = {};
   if (targetIdStr !== null) {
     const targetId = Number(targetIdStr);
     if (!Number.isInteger(targetId) || targetId < 1) {
-      return errorResponse("BAD_REQUEST", "target_id は正の整数で指定してください", 400);
+      return errorResponse("BAD_REQUEST", "targetId は正の整数で指定してください", 400);
     }
-    where.target_id = targetId;
+    where.targetId = targetId;
   }
   if (categoryIdStr !== null) {
     const categoryId = Number(categoryIdStr);
     if (!Number.isInteger(categoryId) || categoryId < 1) {
-      return errorResponse("BAD_REQUEST", "category_id は正の整数で指定してください", 400);
+      return errorResponse("BAD_REQUEST", "categoryId は正の整数で指定してください", 400);
     }
-    where.category_id = categoryId;
+    where.categoryId = categoryId;
   }
 
   const items = await prisma.evaluationItem.findMany({
@@ -32,14 +32,14 @@ export async function GET(request: Request) {
     orderBy: [{ target: { no: "asc" } }, { category: { no: "asc" } }, { no: "asc" }],
     select: {
       id: true,
-      target_id: true,
-      category_id: true,
+      targetId: true,
+      categoryId: true,
       no: true,
       name: true,
       description: true,
-      eval_criteria: true,
+      evalCriteria: true,
       target: { select: { id: true, name: true, no: true } },
-      category: { select: { id: true, target_id: true, name: true, no: true } },
+      category: { select: { id: true, targetId: true, name: true, no: true } },
     },
   });
 

--- a/src/app/api/members/[id]/evaluation-settings/[year]/route.test.ts
+++ b/src/app/api/members/[id]/evaluation-settings/[year]/route.test.ts
@@ -30,20 +30,20 @@ describe("PUT /api/members/:id/evaluation-settings/:year", () => {
     vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as never);
     vi.mocked(prisma.evaluationSetting.upsert).mockResolvedValue({
       id: "setting-1",
-      user_id: "member-1",
-      fiscal_year: 2026,
-      self_evaluation_enabled: false,
+      userId: "member-1",
+      fiscalYear: 2026,
+      selfEvaluationEnabled: false,
     } as never);
 
     const req = new Request("http://localhost", {
       method: "PUT",
-      body: JSON.stringify({ self_evaluation_enabled: false }),
+      body: JSON.stringify({ selfEvaluationEnabled: false }),
     });
     const res = await PUT(req, makeParams("member-1", "2026"));
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body.data).toMatchObject({ fiscal_year: 2026, self_evaluation_enabled: false });
+    expect(body.data).toMatchObject({ fiscalYear: 2026, selfEvaluationEnabled: false });
   });
 
   it("member は更新できない（403）", async () => {
@@ -51,7 +51,7 @@ describe("PUT /api/members/:id/evaluation-settings/:year", () => {
 
     const req = new Request("http://localhost", {
       method: "PUT",
-      body: JSON.stringify({ self_evaluation_enabled: false }),
+      body: JSON.stringify({ selfEvaluationEnabled: false }),
     });
     const res = await PUT(req, makeParams("member-1", "2026"));
 
@@ -63,7 +63,7 @@ describe("PUT /api/members/:id/evaluation-settings/:year", () => {
 
     const req = new Request("http://localhost", {
       method: "PUT",
-      body: JSON.stringify({ self_evaluation_enabled: false }),
+      body: JSON.stringify({ selfEvaluationEnabled: false }),
     });
     const res = await PUT(req, makeParams("member-1", "abc"));
 
@@ -75,7 +75,7 @@ describe("PUT /api/members/:id/evaluation-settings/:year", () => {
 
     const req = new Request("http://localhost", {
       method: "PUT",
-      body: JSON.stringify({ self_evaluation_enabled: "yes" }),
+      body: JSON.stringify({ selfEvaluationEnabled: "yes" }),
     });
     const res = await PUT(req, makeParams("member-1", "2026"));
 
@@ -88,7 +88,7 @@ describe("PUT /api/members/:id/evaluation-settings/:year", () => {
 
     const req = new Request("http://localhost", {
       method: "PUT",
-      body: JSON.stringify({ self_evaluation_enabled: false }),
+      body: JSON.stringify({ selfEvaluationEnabled: false }),
     });
     const res = await PUT(req, makeParams("not-exist", "2026"));
 
@@ -100,7 +100,7 @@ describe("PUT /api/members/:id/evaluation-settings/:year", () => {
 
     const req = new Request("http://localhost", {
       method: "PUT",
-      body: JSON.stringify({ self_evaluation_enabled: false }),
+      body: JSON.stringify({ selfEvaluationEnabled: false }),
     });
     const res = await PUT(req, makeParams("member-1", "2026"));
 

--- a/src/app/api/members/[id]/evaluation-settings/[year]/route.test.ts
+++ b/src/app/api/members/[id]/evaluation-settings/[year]/route.test.ts
@@ -70,7 +70,7 @@ describe("PUT /api/members/:id/evaluation-settings/:year", () => {
     expect(res.status).toBe(400);
   });
 
-  it("self_evaluation_enabled が boolean 以外の場合は 400 を返す", async () => {
+  it("selfEvaluationEnabled が boolean 以外の場合は 400 を返す", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
 
     const req = new Request("http://localhost", {

--- a/src/app/api/members/[id]/evaluation-settings/[year]/route.ts
+++ b/src/app/api/members/[id]/evaluation-settings/[year]/route.ts
@@ -22,8 +22,8 @@ export async function PUT(
   }
 
   const body = await request.json().catch(() => null);
-  if (!body || typeof body.self_evaluation_enabled !== "boolean") {
-    return errorResponse("BAD_REQUEST", "self_evaluation_enabled は boolean で指定してください", 400);
+  if (!body || typeof body.selfEvaluationEnabled !== "boolean") {
+    return errorResponse("BAD_REQUEST", "selfEvaluationEnabled は boolean で指定してください", 400);
   }
 
   const target = await prisma.user.findUnique({ where: { id } });
@@ -32,13 +32,13 @@ export async function PUT(
   }
 
   const setting = await prisma.evaluationSetting.upsert({
-    where: { user_id_fiscal_year: { user_id: id, fiscal_year: fiscalYear } },
-    update: { self_evaluation_enabled: body.self_evaluation_enabled },
-    create: { user_id: id, fiscal_year: fiscalYear, self_evaluation_enabled: body.self_evaluation_enabled },
+    where: { userId_fiscalYear: { userId: id, fiscalYear: fiscalYear } },
+    update: { selfEvaluationEnabled: body.selfEvaluationEnabled },
+    create: { userId: id, fiscalYear: fiscalYear, selfEvaluationEnabled: body.selfEvaluationEnabled },
   });
 
   return successResponse({
-    fiscal_year: setting.fiscal_year,
-    self_evaluation_enabled: setting.self_evaluation_enabled,
+    fiscalYear: setting.fiscalYear,
+    selfEvaluationEnabled: setting.selfEvaluationEnabled,
   });
 }

--- a/src/app/api/members/[id]/evaluation-settings/route.test.ts
+++ b/src/app/api/members/[id]/evaluation-settings/route.test.ts
@@ -19,8 +19,8 @@ const otherMemberSession = { user: { id: "member-2", role: "member" } };
 
 const mockUser = { id: "member-1", name: "山田太郎" };
 const mockSettings = [
-  { fiscal_year: 2026, self_evaluation_enabled: true },
-  { fiscal_year: 2025, self_evaluation_enabled: false },
+  { fiscalYear: 2026, selfEvaluationEnabled: true },
+  { fiscalYear: 2025, selfEvaluationEnabled: false },
 ];
 
 function makeParams(id: string) {
@@ -40,7 +40,7 @@ describe("GET /api/members/:id/evaluation-settings", () => {
 
     expect(res.status).toBe(200);
     expect(body.data).toHaveLength(2);
-    expect(body.data[0]).toMatchObject({ fiscal_year: 2026, self_evaluation_enabled: true });
+    expect(body.data[0]).toMatchObject({ fiscalYear: 2026, selfEvaluationEnabled: true });
   });
 
   it("本人は自分の設定を取得できる", async () => {

--- a/src/app/api/members/[id]/evaluation-settings/route.ts
+++ b/src/app/api/members/[id]/evaluation-settings/route.ts
@@ -26,14 +26,14 @@ export async function GET(
   }
 
   const settings = await prisma.evaluationSetting.findMany({
-    where: { user_id: id },
-    orderBy: { fiscal_year: "desc" },
+    where: { userId: id },
+    orderBy: { fiscalYear: "desc" },
   });
 
   return successResponse(
     settings.map((s) => ({
-      fiscal_year: s.fiscal_year,
-      self_evaluation_enabled: s.self_evaluation_enabled,
+      fiscalYear: s.fiscalYear,
+      selfEvaluationEnabled: s.selfEvaluationEnabled,
     })),
   );
 }

--- a/src/app/api/members/[id]/evaluations/[year]/[itemId]/route.test.ts
+++ b/src/app/api/members/[id]/evaluations/[year]/[itemId]/route.test.ts
@@ -14,7 +14,7 @@ vi.mock("@/lib/prisma", () => ({
 import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 
-const enabledSetting = { id: "s-1", user_id: "user-2", fiscal_year: 2025, self_evaluation_enabled: true };
+const enabledSetting = { id: "s-1", userId: "user-2", fiscalYear: 2025, selfEvaluationEnabled: true };
 
 const makeParams = (id: string, year: string, itemId: string) =>
   Promise.resolve({ id, year, itemId });
@@ -26,13 +26,13 @@ const otherSession = { user: { id: "other-99", role: "member" } };
 
 const mockUpsertResult = {
   id: "eval-1",
-  fiscal_year: 2025,
-  evaluatee_id: "user-2",
-  eval_item_id: 1,
-  self_score: "ryo",
-  self_reason: "理由",
-  manager_score: null,
-  manager_reason: null,
+  fiscalYear: 2025,
+  evaluateeId: "user-2",
+  evalItemId: 1,
+  selfScore: "ryo",
+  selfReason: "理由",
+  managerScore: null,
+  managerReason: null,
 };
 
 describe("PUT /api/members/:id/evaluations/:year/:itemId", () => {
@@ -61,8 +61,8 @@ describe("PUT /api/members/:id/evaluations/:year/:itemId", () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
     vi.mocked(prisma.evaluation.upsert).mockResolvedValue({
       ...mockUpsertResult,
-      manager_score: "yu",
-      manager_reason: "管理者コメント",
+      managerScore: "yu",
+      managerReason: "管理者コメント",
     } as never);
 
     const res = await PUT(
@@ -81,14 +81,14 @@ describe("PUT /api/members/:id/evaluations/:year/:itemId", () => {
     vi.mocked(getSession).mockResolvedValue(evaluatorSession as never);
     vi.mocked(prisma.evaluationAssignment.findFirst).mockResolvedValue({
       id: "assign-1",
-      fiscal_year: 2025,
-      evaluatee_id: "user-2",
-      evaluator_id: "user-1",
+      fiscalYear: 2025,
+      evaluateeId: "user-2",
+      evaluatorId: "user-1",
     });
     vi.mocked(prisma.evaluation.upsert).mockResolvedValue({
       ...mockUpsertResult,
-      manager_score: "ryo",
-      manager_reason: "コメント",
+      managerScore: "ryo",
+      managerReason: "コメント",
     } as never);
 
     const res = await PUT(
@@ -121,9 +121,9 @@ describe("PUT /api/members/:id/evaluations/:year/:itemId", () => {
     vi.mocked(getSession).mockResolvedValue(evaluatorSession as never);
     vi.mocked(prisma.evaluationAssignment.findFirst).mockResolvedValue({
       id: "assign-1",
-      fiscal_year: 2025,
-      evaluatee_id: "user-2",
-      evaluator_id: "user-1",
+      fiscalYear: 2025,
+      evaluateeId: "user-2",
+      evaluatorId: "user-1",
     });
 
     const res = await PUT(
@@ -202,7 +202,7 @@ describe("PUT /api/members/:id/evaluations/:year/:itemId", () => {
     vi.mocked(getSession).mockResolvedValue(selfSession as never);
     vi.mocked(prisma.evaluationSetting.findUnique).mockResolvedValue({
       ...enabledSetting,
-      self_evaluation_enabled: false,
+      selfEvaluationEnabled: false,
     });
 
     const res = await PUT(

--- a/src/app/api/members/[id]/evaluations/[year]/[itemId]/route.ts
+++ b/src/app/api/members/[id]/evaluations/[year]/[itemId]/route.ts
@@ -47,6 +47,7 @@ export async function PUT(
   if (!body || typeof body !== "object") {
     return errorResponse("BAD_REQUEST", "リクエストボディが不正です", 400);
   }
+  // このエンドポイントのリクエスト/レスポンスキーは snake_case を維持する（API contract）
   const { self_score, self_reason, manager_score, manager_reason } = body;
 
   const hasSelfFields = self_score !== undefined || self_reason !== undefined;

--- a/src/app/api/members/[id]/evaluations/[year]/[itemId]/route.ts
+++ b/src/app/api/members/[id]/evaluations/[year]/[itemId]/route.ts
@@ -31,9 +31,9 @@ export async function PUT(
       ? await prisma.evaluationAssignment
           .findFirst({
             where: {
-              fiscal_year: fiscalYear,
-              evaluatee_id: evaluateeId,
-              evaluator_id: currentUserId,
+              fiscalYear: fiscalYear,
+              evaluateeId: evaluateeId,
+              evaluatorId: currentUserId,
             },
           })
           .then((r) => r !== null)
@@ -63,9 +63,9 @@ export async function PUT(
 
   if (hasSelfFields && isSelf) {
     const setting = await prisma.evaluationSetting.findUnique({
-      where: { user_id_fiscal_year: { user_id: evaluateeId, fiscal_year: fiscalYear } },
+      where: { userId_fiscalYear: { userId: evaluateeId, fiscalYear: fiscalYear } },
     });
-    if (!setting?.self_evaluation_enabled) {
+    if (!setting?.selfEvaluationEnabled) {
       return errorResponse("FORBIDDEN", "この年度は自己評価が不要に設定されています", 403);
     }
   }
@@ -79,33 +79,33 @@ export async function PUT(
   }
 
   const updateData: Record<string, unknown> = {};
-  if (self_score !== undefined) updateData.self_score = self_score;
-  if (self_reason !== undefined) updateData.self_reason = self_reason;
-  if (manager_score !== undefined) updateData.manager_score = manager_score;
-  if (manager_reason !== undefined) updateData.manager_reason = manager_reason;
+  if (self_score !== undefined) updateData.selfScore = self_score;
+  if (self_reason !== undefined) updateData.selfReason = self_reason;
+  if (manager_score !== undefined) updateData.managerScore = manager_score;
+  if (manager_reason !== undefined) updateData.managerReason = manager_reason;
 
   const evaluation = await prisma.evaluation.upsert({
     where: {
-      fiscal_year_evaluatee_id_eval_item_id: {
-        fiscal_year: fiscalYear,
-        evaluatee_id: evaluateeId,
-        eval_item_id: itemId,
+      fiscalYear_evaluateeId_evalItemId: {
+        fiscalYear: fiscalYear,
+        evaluateeId: evaluateeId,
+        evalItemId: itemId,
       },
     },
     create: {
-      fiscal_year: fiscalYear,
-      evaluatee_id: evaluateeId,
-      eval_item_id: itemId,
+      fiscalYear: fiscalYear,
+      evaluateeId: evaluateeId,
+      evalItemId: itemId,
       ...updateData,
     },
     update: updateData,
   });
 
   return successResponse({
-    eval_item_id: evaluation.eval_item_id,
-    self_score: evaluation.self_score,
-    self_reason: evaluation.self_reason,
-    manager_score: evaluation.manager_score,
-    manager_reason: evaluation.manager_reason,
+    eval_item_id: evaluation.evalItemId,
+    self_score: evaluation.selfScore,
+    self_reason: evaluation.selfReason,
+    manager_score: evaluation.managerScore,
+    manager_reason: evaluation.managerReason,
   });
 }

--- a/src/app/api/members/[id]/evaluations/[year]/route.test.ts
+++ b/src/app/api/members/[id]/evaluations/[year]/route.test.ts
@@ -22,14 +22,14 @@ const otherSession = { user: { id: "other-99", role: "member" } };
 
 const mockEvaluations = [
   {
-    eval_item_id: 1,
-    fiscal_year: 2025,
-    evaluatee_id: "user-2",
-    self_score: "ryo",
-    self_reason: "理由",
-    manager_score: null,
-    manager_reason: null,
-    evaluation_item: { name: "会社員としての基本姿勢" },
+    evalItemId: 1,
+    fiscalYear: 2025,
+    evaluateeId: "user-2",
+    selfScore: "ryo",
+    selfReason: "理由",
+    managerScore: null,
+    managerReason: null,
+    evaluationItem: { name: "会社員としての基本姿勢" },
   },
 ];
 
@@ -66,9 +66,9 @@ describe("GET /api/members/:id/evaluations/:year", () => {
     vi.mocked(getSession).mockResolvedValue(evaluatorSession as never);
     vi.mocked(prisma.evaluationAssignment.findFirst).mockResolvedValue({
       id: "assign-1",
-      fiscal_year: 2025,
-      evaluatee_id: "user-2",
-      evaluator_id: "user-1",
+      fiscalYear: 2025,
+      evaluateeId: "user-2",
+      evaluatorId: "user-1",
     });
     vi.mocked(prisma.evaluation.findMany).mockResolvedValue(mockEvaluations as never);
 

--- a/src/app/api/members/[id]/evaluations/[year]/route.ts
+++ b/src/app/api/members/[id]/evaluations/[year]/route.ts
@@ -25,9 +25,9 @@ export async function GET(
   const isAssignedEvaluator = !isSelf && !isAdmin
     ? await prisma.evaluationAssignment.findFirst({
         where: {
-          fiscal_year: fiscalYear,
-          evaluatee_id: evaluateeId,
-          evaluator_id: currentUserId,
+          fiscalYear: fiscalYear,
+          evaluateeId: evaluateeId,
+          evaluatorId: currentUserId,
         },
       }).then((r) => r !== null)
     : false;
@@ -37,19 +37,19 @@ export async function GET(
   }
 
   const evaluations = await prisma.evaluation.findMany({
-    where: { fiscal_year: fiscalYear, evaluatee_id: evaluateeId },
-    include: { evaluation_item: { select: { name: true } } },
-    orderBy: { eval_item_id: "asc" },
+    where: { fiscalYear: fiscalYear, evaluateeId: evaluateeId },
+    include: { evaluationItem: { select: { name: true } } },
+    orderBy: { evalItemId: "asc" },
   });
 
   return successResponse(
     evaluations.map((e) => ({
-      eval_item_id: e.eval_item_id,
-      item_name: e.evaluation_item.name,
-      self_score: e.self_score,
-      self_reason: e.self_reason,
-      manager_score: e.manager_score,
-      manager_reason: e.manager_reason,
+      eval_item_id: e.evalItemId,
+      item_name: e.evaluationItem.name,
+      self_score: e.selfScore,
+      self_reason: e.selfReason,
+      manager_score: e.managerScore,
+      manager_reason: e.managerReason,
     })),
   );
 }

--- a/src/components/admin/CategoryActions.tsx
+++ b/src/components/admin/CategoryActions.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
-type Category = { id: number; target_id: number; name: string; no: number };
+type Category = { id: number; targetId: number; name: string; no: number };
 type Props = { category: Category; canDelete: boolean };
 
 export function CategoryActions({ category, canDelete }: Props) {

--- a/src/components/admin/CategoryForm.tsx
+++ b/src/components/admin/CategoryForm.tsx
@@ -18,7 +18,7 @@ export function CategoryForm({ targetId }: Props) {
       const res = await fetch("/api/admin/categories", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ target_id: targetId, name: form.name, no: Number(form.no) }),
+        body: JSON.stringify({ targetId: targetId, name: form.name, no: Number(form.no) }),
       });
       if (res.ok) {
         setOpen(false);

--- a/src/components/admin/EvaluationItemActions.tsx
+++ b/src/components/admin/EvaluationItemActions.tsx
@@ -7,7 +7,7 @@ type EvaluationItem = {
   id: number;
   name: string;
   description: string | null;
-  eval_criteria: string | null;
+  evalCriteria: string | null;
 };
 
 type Props = { item: EvaluationItem; hasEvaluations: boolean };
@@ -19,7 +19,7 @@ export function EvaluationItemActions({ item, hasEvaluations }: Props) {
   const [form, setForm] = useState({
     name: item.name,
     description: item.description ?? "",
-    eval_criteria: item.eval_criteria ?? "",
+    evalCriteria: item.evalCriteria ?? "",
   });
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
@@ -37,7 +37,7 @@ export function EvaluationItemActions({ item, hasEvaluations }: Props) {
         body: JSON.stringify({
           name: form.name,
           description: form.description || null,
-          eval_criteria: form.eval_criteria || null,
+          evalCriteria: form.evalCriteria || null,
         }),
       });
       if (res.ok) {
@@ -93,8 +93,8 @@ export function EvaluationItemActions({ item, hasEvaluations }: Props) {
           className="rounded border border-gray-300 px-2 py-1 text-xs"
         />
         <textarea
-          name="eval_criteria"
-          value={form.eval_criteria}
+          name="evalCriteria"
+          value={form.evalCriteria}
           onChange={handleChange}
           placeholder="評価基準"
           rows={2}

--- a/src/components/admin/EvaluationItemForm.tsx
+++ b/src/components/admin/EvaluationItemForm.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 type Target = { id: number; name: string };
-type Category = { id: number; target_id: number; name: string };
+type Category = { id: number; targetId: number; name: string };
 
 type Props = {
   targets: Target[];
@@ -16,21 +16,21 @@ export function EvaluationItemForm({ targets, categories }: Props) {
   const [loading, setLoading] = useState(false);
   const [open, setOpen] = useState(false);
   const [form, setForm] = useState({
-    target_id: "",
-    category_id: "",
+    targetId: "",
+    categoryId: "",
     name: "",
     description: "",
-    eval_criteria: "",
+    evalCriteria: "",
   });
 
-  const filteredCategories = form.target_id
-    ? categories.filter((c) => c.target_id === Number(form.target_id))
+  const filteredCategories = form.targetId
+    ? categories.filter((c) => c.targetId === Number(form.targetId))
     : [];
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) {
     const { name, value } = e.target;
-    if (name === "target_id") {
-      setForm((prev) => ({ ...prev, target_id: value, category_id: "" }));
+    if (name === "targetId") {
+      setForm((prev) => ({ ...prev, targetId: value, categoryId: "" }));
     } else {
       setForm((prev) => ({ ...prev, [name]: value }));
     }
@@ -44,16 +44,16 @@ export function EvaluationItemForm({ targets, categories }: Props) {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          target_id: Number(form.target_id),
-          category_id: Number(form.category_id),
+          targetId: Number(form.targetId),
+          categoryId: Number(form.categoryId),
           name: form.name,
           description: form.description || null,
-          eval_criteria: form.eval_criteria || null,
+          evalCriteria: form.evalCriteria || null,
         }),
       });
       if (res.ok) {
         setOpen(false);
-        setForm({ target_id: "", category_id: "", name: "", description: "", eval_criteria: "" });
+        setForm({ targetId: "", categoryId: "", name: "", description: "", evalCriteria: "" });
         router.refresh();
       } else {
         const json = await res.json().catch(() => ({}));
@@ -83,14 +83,14 @@ export function EvaluationItemForm({ targets, categories }: Props) {
       <h3 className="mb-4 font-medium text-gray-900">新しい評価項目を追加</h3>
       <div className="grid grid-cols-2 gap-4">
         <div>
-          <label htmlFor="target_id" className="mb-1 block text-xs font-medium text-gray-700">
+          <label htmlFor="targetId" className="mb-1 block text-xs font-medium text-gray-700">
             大分類 <span className="text-red-500">*</span>
           </label>
           <select
-            id="target_id"
-            name="target_id"
+            id="targetId"
+            name="targetId"
             required
-            value={form.target_id}
+            value={form.targetId}
             onChange={handleChange}
             className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
           >
@@ -101,16 +101,16 @@ export function EvaluationItemForm({ targets, categories }: Props) {
           </select>
         </div>
         <div>
-          <label htmlFor="category_id" className="mb-1 block text-xs font-medium text-gray-700">
+          <label htmlFor="categoryId" className="mb-1 block text-xs font-medium text-gray-700">
             中分類 <span className="text-red-500">*</span>
           </label>
           <select
-            id="category_id"
-            name="category_id"
+            id="categoryId"
+            name="categoryId"
             required
-            value={form.category_id}
+            value={form.categoryId}
             onChange={handleChange}
-            disabled={!form.target_id}
+            disabled={!form.targetId}
             className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none disabled:bg-gray-50 disabled:text-gray-400"
           >
             <option value="">選択してください</option>
@@ -147,13 +147,13 @@ export function EvaluationItemForm({ targets, categories }: Props) {
           />
         </div>
         <div className="col-span-2">
-          <label htmlFor="eval_criteria" className="mb-1 block text-xs font-medium text-gray-700">
+          <label htmlFor="evalCriteria" className="mb-1 block text-xs font-medium text-gray-700">
             評価基準
           </label>
           <textarea
-            id="eval_criteria"
-            name="eval_criteria"
-            value={form.eval_criteria}
+            id="evalCriteria"
+            name="evalCriteria"
+            value={form.evalCriteria}
             onChange={handleChange}
             rows={2}
             className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"

--- a/src/components/admin/EvaluationSettingToggle.tsx
+++ b/src/components/admin/EvaluationSettingToggle.tsx
@@ -19,7 +19,7 @@ export function EvaluationSettingToggle({ userId, fiscalYear, enabled }: Props) 
       const res = await fetch(`/api/members/${userId}/evaluation-settings/${fiscalYear}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ self_evaluation_enabled: !enabled }),
+        body: JSON.stringify({ selfEvaluationEnabled: !enabled }),
       });
       if (res.ok) {
         router.refresh();

--- a/src/components/admin/FiscalYearActions.tsx
+++ b/src/components/admin/FiscalYearActions.tsx
@@ -6,9 +6,9 @@ import { useState } from "react";
 type FiscalYear = {
   year: number;
   name: string;
-  start_date: Date;
-  end_date: Date;
-  is_current: boolean;
+  startDate: Date;
+  endDate: Date;
+  isCurrent: boolean;
 };
 
 type Props = { fiscalYear: FiscalYear };
@@ -19,8 +19,8 @@ export function FiscalYearActions({ fiscalYear }: Props) {
   const [editing, setEditing] = useState(false);
   const [form, setForm] = useState({
     name: fiscalYear.name,
-    start_date: fiscalYear.start_date.toISOString().slice(0, 10),
-    end_date: fiscalYear.end_date.toISOString().slice(0, 10),
+    startDate: fiscalYear.startDate.toISOString().slice(0, 10),
+    endDate: fiscalYear.endDate.toISOString().slice(0, 10),
   });
 
   async function handleSetCurrent() {
@@ -30,7 +30,7 @@ export function FiscalYearActions({ fiscalYear }: Props) {
       const res = await fetch(`/api/admin/fiscal-years/${fiscalYear.year}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ is_current: true }),
+        body: JSON.stringify({ isCurrent: true }),
       });
       if (res.ok) {
         router.refresh();
@@ -99,15 +99,15 @@ export function FiscalYearActions({ fiscalYear }: Props) {
         />
         <input
           type="date"
-          value={form.start_date}
-          onChange={(e) => setForm((p) => ({ ...p, start_date: e.target.value }))}
+          value={form.startDate}
+          onChange={(e) => setForm((p) => ({ ...p, startDate: e.target.value }))}
           className="rounded border border-gray-300 px-2 py-1 text-xs"
           required
         />
         <input
           type="date"
-          value={form.end_date}
-          onChange={(e) => setForm((p) => ({ ...p, end_date: e.target.value }))}
+          value={form.endDate}
+          onChange={(e) => setForm((p) => ({ ...p, endDate: e.target.value }))}
           className="rounded border border-gray-300 px-2 py-1 text-xs"
           required
         />
@@ -132,7 +132,7 @@ export function FiscalYearActions({ fiscalYear }: Props) {
 
   return (
     <div className="flex justify-end gap-2">
-      {!fiscalYear.is_current && (
+      {!fiscalYear.isCurrent && (
         <button
           type="button"
           onClick={handleSetCurrent}

--- a/src/components/admin/FiscalYearForm.tsx
+++ b/src/components/admin/FiscalYearForm.tsx
@@ -7,7 +7,7 @@ export function FiscalYearForm() {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [open, setOpen] = useState(false);
-  const [form, setForm] = useState({ year: "", name: "", start_date: "", end_date: "" });
+  const [form, setForm] = useState({ year: "", name: "", startDate: "", endDate: "" });
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     const { name, value } = e.target;
@@ -31,13 +31,13 @@ export function FiscalYearForm() {
         body: JSON.stringify({
           year: Number(form.year),
           name: form.name,
-          start_date: form.start_date,
-          end_date: form.end_date,
+          startDate: form.startDate,
+          endDate: form.endDate,
         }),
       });
       if (res.ok) {
         setOpen(false);
-        setForm({ year: "", name: "", start_date: "", end_date: "" });
+        setForm({ year: "", name: "", startDate: "", endDate: "" });
         router.refresh();
       } else {
         const json = await res.json().catch(() => ({}));
@@ -97,29 +97,29 @@ export function FiscalYearForm() {
           />
         </div>
         <div>
-          <label htmlFor="start_date" className="mb-1 block text-xs font-medium text-gray-700">
+          <label htmlFor="startDate" className="mb-1 block text-xs font-medium text-gray-700">
             開始日
           </label>
           <input
-            id="start_date"
-            name="start_date"
+            id="startDate"
+            name="startDate"
             type="date"
             required
-            value={form.start_date}
+            value={form.startDate}
             onChange={handleChange}
             className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
           />
         </div>
         <div>
-          <label htmlFor="end_date" className="mb-1 block text-xs font-medium text-gray-700">
+          <label htmlFor="endDate" className="mb-1 block text-xs font-medium text-gray-700">
             終了日
           </label>
           <input
-            id="end_date"
-            name="end_date"
+            id="endDate"
+            name="endDate"
             type="date"
             required
-            value={form.end_date}
+            value={form.endDate}
             onChange={handleChange}
             className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
           />

--- a/src/components/admin/UserActions.tsx
+++ b/src/components/admin/UserActions.tsx
@@ -48,7 +48,7 @@ export function UserActions({ userId, currentRole, isActive, isSelf }: Props) {
       const res = await fetch(`/api/admin/users/${userId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ is_active: !isActive }),
+        body: JSON.stringify({ isActive: !isActive }),
       });
       if (res.ok) {
         router.refresh();

--- a/src/components/evaluation/EvaluationTabs.tsx
+++ b/src/components/evaluation/EvaluationTabs.tsx
@@ -17,11 +17,11 @@ type Item = {
   uid: string;
   name: string;
   description: string | null;
-  eval_criteria: string | null;
+  evalCriteria: string | null;
   category: string;
   target: string;
-  self_score: Score | null;
-  self_reason: string | null;
+  selfScore: Score | null;
+  selfReason: string | null;
 };
 
 type Props = {
@@ -35,10 +35,10 @@ export default function EvaluationTabs({ items, userId, fiscalYear }: Props) {
   const [activeCategory, setActiveCategory] = useState(categories[0] ?? "");
 
   const [scores, setScores] = useState<Record<number, Score>>(
-    Object.fromEntries(items.map((i) => [i.id, i.self_score ?? "none"])),
+    Object.fromEntries(items.map((i) => [i.id, i.selfScore ?? "none"])),
   );
   const [reasons, setReasons] = useState<Record<number, string>>(
-    Object.fromEntries(items.map((i) => [i.id, i.self_reason ?? ""])),
+    Object.fromEntries(items.map((i) => [i.id, i.selfReason ?? ""])),
   );
   const [saving, setSaving] = useState<Record<number, boolean>>({});
   const [saved, setSaved] = useState<Record<number, boolean>>({});
@@ -107,9 +107,9 @@ export default function EvaluationTabs({ items, userId, fiscalYear }: Props) {
               {item.description && (
                 <p className="mt-1 text-sm text-gray-600">{item.description}</p>
               )}
-              {item.eval_criteria && (
+              {item.evalCriteria && (
                 <p className="mt-1 text-xs text-gray-400">
-                  評価基準: {item.eval_criteria}
+                  評価基準: {item.evalCriteria}
                 </p>
               )}
             </div>

--- a/src/components/evaluation/ManagerEvaluationTabs.tsx
+++ b/src/components/evaluation/ManagerEvaluationTabs.tsx
@@ -17,13 +17,13 @@ type Item = {
   uid: string;
   name: string;
   description: string | null;
-  eval_criteria: string | null;
+  evalCriteria: string | null;
   category: string;
   target: string;
-  self_score: Score | null;
-  self_reason: string | null;
-  manager_score: Score | null;
-  manager_reason: string | null;
+  selfScore: Score | null;
+  selfReason: string | null;
+  managerScore: Score | null;
+  managerReason: string | null;
 };
 
 type Props = {
@@ -37,10 +37,10 @@ export default function ManagerEvaluationTabs({ items, evaluateeId, fiscalYear }
   const [activeCategory, setActiveCategory] = useState(categories[0] ?? "");
 
   const [scores, setScores] = useState<Record<number, Score>>(
-    Object.fromEntries(items.map((i) => [i.id, i.manager_score ?? "none"])),
+    Object.fromEntries(items.map((i) => [i.id, i.managerScore ?? "none"])),
   );
   const [reasons, setReasons] = useState<Record<number, string>>(
-    Object.fromEntries(items.map((i) => [i.id, i.manager_reason ?? ""])),
+    Object.fromEntries(items.map((i) => [i.id, i.managerReason ?? ""])),
   );
   const [saving, setSaving] = useState<Record<number, boolean>>({});
   const [saved, setSaved] = useState<Record<number, boolean>>({});
@@ -121,9 +121,9 @@ export default function ManagerEvaluationTabs({ items, evaluateeId, fiscalYear }
               {item.description && (
                 <p className="mt-1 text-sm text-gray-600">{item.description}</p>
               )}
-              {item.eval_criteria && (
+              {item.evalCriteria && (
                 <p className="mt-1 text-xs text-gray-400">
-                  評価基準: {item.eval_criteria}
+                  評価基準: {item.evalCriteria}
                 </p>
               )}
             </div>
@@ -133,10 +133,10 @@ export default function ManagerEvaluationTabs({ items, evaluateeId, fiscalYear }
               <p className="mb-1 text-xs font-medium text-gray-500">自己評価（参考）</p>
               <div className="flex items-center gap-3">
                 <span className="rounded-md bg-white px-2 py-1 text-sm font-medium text-gray-700 border">
-                  {item.self_score ? SCORE_LABELS[item.self_score] : "未入力"}
+                  {item.selfScore ? SCORE_LABELS[item.selfScore] : "未入力"}
                 </span>
-                {item.self_reason && (
-                  <span className="text-sm text-gray-600">{item.self_reason}</span>
+                {item.selfReason && (
+                  <span className="text-sm text-gray-600">{item.selfReason}</span>
                 )}
               </div>
             </div>

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -48,7 +48,7 @@ describe("getSession", () => {
         id: "mock-user-id",
         name: "モックユーザー",
         role: "admin",
-        is_active: true,
+        isActive: true,
       });
 
       const result = await getSession();
@@ -58,7 +58,7 @@ describe("getSession", () => {
       expect(mockAuth).not.toHaveBeenCalled();
       expect(mockFindUnique).toHaveBeenCalledWith({
         where: { id: "mock-user-id" },
-        select: { id: true, name: true, role: true, is_active: true },
+        select: { id: true, name: true, role: true, isActive: true },
       });
     });
 
@@ -71,13 +71,13 @@ describe("getSession", () => {
       expect(mockAuth).not.toHaveBeenCalled();
     });
 
-    it("is_active: false のユーザーは null を返す", async () => {
+    it("isActive: false のユーザーは null を返す", async () => {
       // @ts-expect-error
       mockFindUnique.mockResolvedValue({
         id: "mock-user-id",
         name: "無効ユーザー",
         role: "member",
-        is_active: false,
+        isActive: false,
       });
 
       const result = await getSession();
@@ -106,7 +106,7 @@ describe("getSession", () => {
         id: "user-uuid",
         name: "モックユーザー",
         role: "member",
-        is_active: true,
+        isActive: true,
       });
 
       const result = await getSession();
@@ -114,7 +114,7 @@ describe("getSession", () => {
       expect(mockAuth).not.toHaveBeenCalled();
       expect(mockFindUnique).toHaveBeenCalledWith({
         where: { email: "mock@example.com" },
-        select: { id: true, name: true, role: true, is_active: true },
+        select: { id: true, name: true, role: true, isActive: true },
       });
     });
 
@@ -127,13 +127,13 @@ describe("getSession", () => {
       expect(mockAuth).not.toHaveBeenCalled();
     });
 
-    it("is_active: false のユーザーは null を返す", async () => {
+    it("isActive: false のユーザーは null を返す", async () => {
       // @ts-expect-error
       mockFindUnique.mockResolvedValue({
         id: "user-uuid",
         name: "無効ユーザー",
         role: "member",
-        is_active: false,
+        isActive: false,
       });
 
       const result = await getSession();
@@ -147,13 +147,13 @@ describe("getSession", () => {
         id: "priority-user-id",
         name: "優先ユーザー",
         role: "admin",
-        is_active: true,
+        isActive: true,
       });
 
       const result = await getSession();
       expect(mockFindUnique).toHaveBeenCalledWith({
         where: { id: "priority-user-id" },
-        select: { id: true, name: true, role: true, is_active: true },
+        select: { id: true, name: true, role: true, isActive: true },
       });
       expect(result?.user.id).toBe("priority-user-id");
     });
@@ -168,7 +168,7 @@ describe("getSession", () => {
     expect(mockFindUnique).not.toHaveBeenCalled();
   });
 
-  it("正常系: clerk_idに対応するDBユーザーが存在する場合はセッションを返す", async () => {
+  it("正常系: clerkIdに対応するDBユーザーが存在する場合はセッションを返す", async () => {
     // @ts-expect-error
     mockAuth.mockResolvedValue({ userId: "clerk_abc123" });
     // @ts-expect-error
@@ -176,7 +176,7 @@ describe("getSession", () => {
       id: "user-uuid",
       name: "テストユーザー",
       role: "member",
-      is_active: true,
+      isActive: true,
     });
 
     const result = await getSession();
@@ -186,7 +186,7 @@ describe("getSession", () => {
     expect(mockCurrentUser).not.toHaveBeenCalled();
   });
 
-  it("clerk_id で見つかったユーザーが is_active: false の場合は null を返す", async () => {
+  it("clerkId で見つかったユーザーが isActive: false の場合は null を返す", async () => {
     // @ts-expect-error
     mockAuth.mockResolvedValue({ userId: "clerk_abc123" });
     // @ts-expect-error
@@ -194,7 +194,7 @@ describe("getSession", () => {
       id: "user-uuid",
       name: "無効ユーザー",
       role: "member",
-      is_active: false,
+      isActive: false,
     });
 
     const result = await getSession();
@@ -209,27 +209,27 @@ describe("getSession", () => {
       id: "admin-uuid",
       name: "管理者",
       role: "admin",
-      is_active: true,
+      isActive: true,
     });
 
     const result = await getSession();
     expect(result?.user.role).toBe("admin");
   });
 
-  describe("初回ログイン時の clerk_id 自動紐付け", () => {
-    it("メールアドレスが一致するDBユーザーに clerk_id を紐付けてセッションを返す", async () => {
+  describe("初回ログイン時の clerkId 自動紐付け", () => {
+    it("メールアドレスが一致するDBユーザーに clerkId を紐付けてセッションを返す", async () => {
       // @ts-expect-error
       mockAuth.mockResolvedValue({ userId: "clerk_new123" });
       // @ts-expect-error
       mockFindUnique
-        .mockResolvedValueOnce(null) // clerk_id 検索 → 未ヒット
+        .mockResolvedValueOnce(null) // clerkId 検索 → 未ヒット
         // @ts-expect-error
         .mockResolvedValueOnce({
           id: "user-uuid",
           name: "田中太郎",
           role: "member",
-          clerk_id: null,
-          is_active: true,
+          clerkId: null,
+          isActive: true,
         }); // email 検索
       // @ts-expect-error
       mockCurrentUser.mockResolvedValue({
@@ -243,31 +243,31 @@ describe("getSession", () => {
         user: { id: "user-uuid", name: "田中太郎", role: "member" },
       });
       expect(mockUpdateMany).toHaveBeenCalledWith({
-        where: { email: "tanaka@example.com", clerk_id: null },
-        data: { clerk_id: "clerk_new123" },
+        where: { email: "tanaka@example.com", clerkId: null },
+        data: { clerkId: "clerk_new123" },
       });
     });
 
-    it("並行リクエストで先に clerk_id が紐付け済みの場合は既存レコードを返す", async () => {
+    it("並行リクエストで先に clerkId が紐付け済みの場合は既存レコードを返す", async () => {
       // @ts-expect-error
       mockAuth.mockResolvedValue({ userId: "clerk_new123" });
       // @ts-expect-error
       mockFindUnique
-        .mockResolvedValueOnce(null) // clerk_id 検索 → 未ヒット
+        .mockResolvedValueOnce(null) // clerkId 検索 → 未ヒット
         // @ts-expect-error
         .mockResolvedValueOnce({
           id: "user-uuid",
           name: "田中太郎",
           role: "member",
-          clerk_id: null,
-          is_active: true,
+          clerkId: null,
+          isActive: true,
         }) // email 検索
         // @ts-expect-error
         .mockResolvedValueOnce({
           id: "user-uuid",
           name: "田中太郎",
           role: "member",
-          is_active: true,
+          isActive: true,
         }); // updateMany count=0 後の再取得
       // @ts-expect-error
       mockCurrentUser.mockResolvedValue({
@@ -287,7 +287,7 @@ describe("getSession", () => {
       mockAuth.mockResolvedValue({ userId: "clerk_new123" });
       // @ts-expect-error
       mockFindUnique
-        .mockResolvedValueOnce(null) // clerk_id 検索 → 未ヒット
+        .mockResolvedValueOnce(null) // clerkId 検索 → 未ヒット
         .mockResolvedValueOnce(null); // email 検索 → 未ヒット
       // @ts-expect-error
       mockCurrentUser.mockResolvedValue({
@@ -304,7 +304,7 @@ describe("getSession", () => {
       });
       expect(mockCreate).toHaveBeenCalledWith({
         data: {
-          clerk_id: "clerk_new123",
+          clerkId: "clerk_new123",
           email: "new@example.com",
           name: "新規ユーザー",
           role: "member",
@@ -314,19 +314,19 @@ describe("getSession", () => {
       expect(mockUpdateMany).not.toHaveBeenCalled();
     });
 
-    it("既に別の clerk_id に紐付き済みのDBユーザーはnullを返す", async () => {
+    it("既に別の clerkId に紐付き済みのDBユーザーはnullを返す", async () => {
       // @ts-expect-error
       mockAuth.mockResolvedValue({ userId: "clerk_new123" });
       // @ts-expect-error
       mockFindUnique
-        .mockResolvedValueOnce(null) // clerk_id 検索 → 未ヒット
+        .mockResolvedValueOnce(null) // clerkId 検索 → 未ヒット
         // @ts-expect-error
         .mockResolvedValueOnce({
           id: "user-uuid",
           name: "田中太郎",
           role: "member",
-          clerk_id: "clerk_other",
-          is_active: true,
+          clerkId: "clerk_other",
+          isActive: true,
         }); // email 検索 → 別IDに紐付き済み
       // @ts-expect-error
       mockCurrentUser.mockResolvedValue({
@@ -338,19 +338,19 @@ describe("getSession", () => {
       expect(mockUpdateMany).not.toHaveBeenCalled();
     });
 
-    it("email で見つかったユーザーが is_active: false の場合は null を返す", async () => {
+    it("email で見つかったユーザーが isActive: false の場合は null を返す", async () => {
       // @ts-expect-error
       mockAuth.mockResolvedValue({ userId: "clerk_new123" });
       // @ts-expect-error
       mockFindUnique
-        .mockResolvedValueOnce(null) // clerk_id 検索 → 未ヒット
+        .mockResolvedValueOnce(null) // clerkId 検索 → 未ヒット
         // @ts-expect-error
         .mockResolvedValueOnce({
           id: "user-uuid",
           name: "無効ユーザー",
           role: "member",
-          clerk_id: null,
-          is_active: false,
+          clerkId: null,
+          isActive: false,
         }); // email 検索
       // @ts-expect-error
       mockCurrentUser.mockResolvedValue({

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -16,17 +16,17 @@ export async function getSession(): Promise<Session | null> {
     if (process.env.MOCK_USER_ID) {
       const user = await prisma.user.findUnique({
         where: { id: process.env.MOCK_USER_ID },
-        select: { id: true, name: true, role: true, is_active: true },
+        select: { id: true, name: true, role: true, isActive: true },
       });
-      if (!user || !user.is_active) return null;
+      if (!user || !user.isActive) return null;
       return { user: { id: user.id, name: user.name, role: user.role } };
     }
     if (process.env.MOCK_USER_EMAIL) {
       const user = await prisma.user.findUnique({
         where: { email: process.env.MOCK_USER_EMAIL },
-        select: { id: true, name: true, role: true, is_active: true },
+        select: { id: true, name: true, role: true, isActive: true },
       });
-      if (!user || !user.is_active) return null;
+      if (!user || !user.isActive) return null;
       return { user: { id: user.id, name: user.name, role: user.role } };
     }
   }
@@ -34,14 +34,14 @@ export async function getSession(): Promise<Session | null> {
   const { userId } = await auth();
   if (!userId) return null;
 
-  // まず clerk_id で検索
+  // まず clerkId で検索
   const userByClerkId = await prisma.user.findUnique({
-    where: { clerk_id: userId },
-    select: { id: true, name: true, role: true, is_active: true },
+    where: { clerkId: userId },
+    select: { id: true, name: true, role: true, isActive: true },
   });
 
   if (userByClerkId) {
-    if (!userByClerkId.is_active) return null;
+    if (!userByClerkId.isActive) return null;
     return { user: { id: userByClerkId.id, name: userByClerkId.name, role: userByClerkId.role } };
   }
 
@@ -52,7 +52,7 @@ export async function getSession(): Promise<Session | null> {
 
   const existingUser = await prisma.user.findUnique({
     where: { email },
-    select: { id: true, name: true, role: true, clerk_id: true, is_active: true },
+    select: { id: true, name: true, role: true, clerkId: true, isActive: true },
   });
 
   if (!existingUser) {
@@ -61,7 +61,7 @@ export async function getSession(): Promise<Session | null> {
     const name = clerkUser?.fullName ?? clerkUser?.firstName ?? email;
     try {
       const created = await prisma.user.create({
-        data: { clerk_id: userId, email, name, role: "member" },
+        data: { clerkId: userId, email, name, role: "member" },
         select: { id: true, name: true, role: true },
       });
       return { user: created };
@@ -69,33 +69,33 @@ export async function getSession(): Promise<Session | null> {
       if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
         const user = await prisma.user.findUnique({
           where: { email },
-          select: { id: true, name: true, role: true, is_active: true },
+          select: { id: true, name: true, role: true, isActive: true },
         });
-        if (!user || !user.is_active) return null;
+        if (!user || !user.isActive) return null;
         return { user: { id: user.id, name: user.name, role: user.role } };
       }
       throw e;
     }
   }
 
-  if (existingUser.clerk_id) {
+  if (existingUser.clerkId) {
     return null; // 既に別の Clerk ID に紐付き済み
   }
 
-  if (!existingUser.is_active) return null;
+  if (!existingUser.isActive) return null;
 
-  // clerk_id: null の場合のみ更新（並行リクエストによる上書き防止）
+  // clerkId: null の場合のみ更新（並行リクエストによる上書き防止）
   const { count } = await prisma.user.updateMany({
-    where: { email, clerk_id: null },
-    data: { clerk_id: userId },
+    where: { email, clerkId: null },
+    data: { clerkId: userId },
   });
   if (count === 0) {
     // 別リクエストが先に紐付けを完了した場合は再取得して返す
     const user = await prisma.user.findUnique({
       where: { email },
-      select: { id: true, name: true, role: true, is_active: true },
+      select: { id: true, name: true, role: true, isActive: true },
     });
-    if (!user || !user.is_active) return null;
+    if (!user || !user.isActive) return null;
     return { user: { id: user.id, name: user.name, role: user.role } };
   }
 

--- a/src/lib/fiscal-year.test.ts
+++ b/src/lib/fiscal-year.test.ts
@@ -13,12 +13,12 @@ import { getCurrentFiscalYear } from "./fiscal-year";
 describe("getCurrentFiscalYear", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("is_current=true の年度を返す", async () => {
+  it("isCurrent=true の年度を返す", async () => {
     vi.mocked(prisma.fiscalYear.findFirst).mockResolvedValue({ year: 2026 } as never);
     expect(await getCurrentFiscalYear()).toBe(2026);
   });
 
-  it("is_current=true の年度がない場合は null を返す", async () => {
+  it("isCurrent=true の年度がない場合は null を返す", async () => {
     vi.mocked(prisma.fiscalYear.findFirst).mockResolvedValue(null);
     expect(await getCurrentFiscalYear()).toBeNull();
   });

--- a/src/lib/fiscal-year.ts
+++ b/src/lib/fiscal-year.ts
@@ -6,7 +6,7 @@ import { prisma } from "@/lib/prisma";
  */
 export async function getCurrentFiscalYear(): Promise<number | null> {
   const fy = await prisma.fiscalYear.findFirst({
-    where: { is_current: true },
+    where: { isCurrent: true },
     select: { year: true },
   });
   return fy?.year ?? null;


### PR DESCRIPTION
## Summary

- Prismaスキーマの全フィールド名をsnake_caseからcamelCaseに変更し、`@map("snake_case_name")`でDBカラム名をマッピング
- APIルート・テスト・UIページ・コンポーネント（計59ファイル）を一括対応
- 全194テスト通過

## 変更ファイル

- `prisma/schema.prisma` — 全モデルのフィールド名をcamelCaseに変更
- `prisma/seed.ts` — Prismaフィールド参照を更新
- `src/lib/` — `auth.ts`, `fiscal-year.ts` とテスト
- `src/app/api/` — 全APIルートとテスト（リクエストボディのキーもcamelCaseに統一）
- `src/app/(dashboard)/` — 全ページのPrismaクエリを更新
- `src/components/` — 全コンポーネントのAPIリクエストボディとprops型を更新
- `CLAUDE.md` — Prismaスキーマのカラム名ルールを追記

## Test plan

- [x] `npm test` — 194 tests passed (22 test files)

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)