### PR TITLE
feat: T129 seed.ts をE2Eテスト用に再作成（daily-hub ユーザー踏襲）

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -96,15 +96,16 @@ npx prisma db seed
 
 シードで作成されるユーザーとパスワードは以下の通り（開発用）：
 
-**共通パスワード**: `AmericanDogs`
+**共通パスワード**: `Yakitori2026`
 
-| email | name | role | 検証シナリオ |
-|-------|------|------|------------|
-| doigaki@example.com | 土井垣将 | admin | 自己評価なし・評価アサインなし |
-| shiranui@example.com | 不知火守 | admin | 2025のみ自己評価あり・上長評価される |
-| yamada@example.com | 山田太郎 | member | 通年自己評価あり・評価者かつ被評価者 |
-| satonaka@example.com | 里中智 | member | 通年自己評価あり・複数の上長に評価される |
-| iwaki@example.com | 岩鬼正美 | member | 通年自己評価なし・評価アサインなし |
+| email | role | isActive | 検証シナリオ |
+|-------|------|----------|------------|
+| bonjiri@example.com | ADMIN | true | 自己評価なし・評価アサインなし（管理操作確認用） |
+| tsukune@example.com | ADMIN | true | 2025のみ自己評価あり・上長評価される |
+| tebasaki@example.com | MEMBER | true | 通年自己評価あり・評価者かつ被評価者・採点データあり |
+| nankotsu@example.com | MEMBER | true | 通年自己評価あり・複数の上長に評価される |
+| sunagimo@example.com | MEMBER | false | 無効化ユーザー（auth-error リダイレクト確認用） |
+| torikawa@example.com | MEMBER | true | 評価なし・アサインなし（削除テスト用） |
 
 > Clerk へのユーザー作成は `NODE_ENV !== 'production'` の場合のみ実行される。本番環境ではスキップされる。
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -87,11 +87,12 @@ vi.mock("@/lib/auth", () => ({
 
 | メール | ロール | isActive | 主な用途 |
 |--------|--------|----------|---------|
-| `doigaki@example.com` | admin | true | 管理画面の操作確認（評価なし） |
-| `shiranui@example.com` | admin | true | 評価者・管理者の複合確認 |
-| `yamada@example.com` | member | true | 被評価者のメインユーザー |
-| `satonaka@example.com` | member | true | ユーザー分離テスト |
-| `iwaki@example.com` | member | true | 評価なし状態の確認 |
+| `bonjiri@example.com` | ADMIN | true | 管理画面の操作確認（自己評価なし・アサインなし） |
+| `tsukune@example.com` | ADMIN | true | 評価者・管理者の複合確認（2025のみ自己評価） |
+| `tebasaki@example.com` | MEMBER | true | 被評価者のメインユーザー（通年自己評価・採点データあり） |
+| `nankotsu@example.com` | MEMBER | true | ユーザー分離テスト（通年自己評価） |
+| `sunagimo@example.com` | MEMBER | false | auth-error リダイレクト確認（isActive=false） |
+| `torikawa@example.com` | MEMBER | true | 削除テスト用（関連データなし） |
 
 ### Playwright MCP への指示例
 
@@ -121,13 +122,16 @@ docs/e2e-scenarios.md の [テストしたいセクション名] を参照して
 
 ### 投入データ
 
-| ユーザー名 | メール | ロール | 評価状況 |
-|-----------|--------|--------|---------|
-| 土井垣将 | `doigaki@example.com` | admin | 評価なし |
-| 不知火守 | `shiranui@example.com` | admin | 2025年度 自己評価あり |
-| 山田太郎 | `yamada@example.com` | member | 全年度 評価あり（評価者: 土井垣/不知火） |
-| 里中智 | `satonaka@example.com` | member | 全年度 評価あり（評価者: 不知火/山田） |
-| 岩鬼正美 | `iwaki@example.com` | member | 評価なし |
+**共通パスワード**: `Yakitori2026`
+
+| メール | ロール | isActive | 評価状況 |
+|--------|--------|----------|---------|
+| `bonjiri@example.com` | ADMIN | true | 評価なし・アサインなし |
+| `tsukune@example.com` | ADMIN | true | 2025年度 自己評価あり（評価者: bonjiri） |
+| `tebasaki@example.com` | MEMBER | true | 全年度 評価あり・採点データあり（評価者: bonjiri/tsukune） |
+| `nankotsu@example.com` | MEMBER | true | 全年度 評価あり（評価者: tsukune/tebasaki） |
+| `sunagimo@example.com` | MEMBER | false | 無効化ユーザー（auth-error テスト用） |
+| `torikawa@example.com` | MEMBER | true | 評価なし・アサインなし（削除テスト用） |
 
 年度: 2025・2026（current）・2027
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -75,7 +75,7 @@ async function seedFiscalYearItems(allItemIds: number[]) {
 
 async function main() {
   // =========================================================================
-  // 0. 旧 seed ユーザーのクリーンアップ
+  // 0. 旧 seed ユーザーのクリーンアップ（旧メールアドレスのユーザーを DB・Clerk から削除）
   // =========================================================================
   const oldEmails = [
     // 旧ユーザー（ドカベンキャラクター）
@@ -90,6 +90,30 @@ async function main() {
     "sato@example.com",
   ];
   for (const email of oldEmails) await cleanupUser(email);
+
+  // =========================================================================
+  // 0-2. 現 seed ユーザーの可変データを初期化
+  //      E2E テストで追加されたデータを毎回クリーンな状態に戻す
+  //      （ユーザー自体は削除しない。Clerk ユーザーも保持する）
+  // =========================================================================
+  const seedEmails = [
+    "bonjiri@example.com",
+    "tsukune@example.com",
+    "tebasaki@example.com",
+    "nankotsu@example.com",
+    "sunagimo@example.com",
+    "torikawa@example.com",
+  ];
+  for (const email of seedEmails) {
+    const user = await prisma.user.findUnique({ where: { email } });
+    if (!user) continue;
+    await prisma.evaluation.deleteMany({ where: { evaluateeId: user.id } });
+    await prisma.evaluationAssignment.deleteMany({
+      where: { OR: [{ evaluateeId: user.id }, { evaluatorId: user.id }] },
+    });
+    await prisma.evaluationSetting.deleteMany({ where: { userId: user.id } });
+  }
+  console.log("seed users: evaluations / assignments / settings cleared");
 
   // =========================================================================
   // 1. ユーザー

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -29,7 +29,7 @@ async function syncClerkUser(email: string): Promise<string | null> {
   if (existing.data.length > 0) return existing.data[0].id;
   const created = await clerkClient.users.createUser({
     emailAddress: [email],
-    password: "AmericanDogs",
+    password: "Yakitori2026",
     skipPasswordChecks: true,
   });
   return created.id;
@@ -77,29 +77,44 @@ async function main() {
   // =========================================================================
   // 0. 旧 seed ユーザーのクリーンアップ
   // =========================================================================
-  const oldEmails = ["tanaka@example.com", "suzuki@example.com", "sato@example.com"];
+  const oldEmails = [
+    // 旧ユーザー（ドカベンキャラクター）
+    "doigaki@example.com",
+    "shiranui@example.com",
+    "yamada@example.com",
+    "satonaka@example.com",
+    "iwaki@example.com",
+    // さらに旧ユーザー
+    "tanaka@example.com",
+    "suzuki@example.com",
+    "sato@example.com",
+  ];
   for (const email of oldEmails) await cleanupUser(email);
 
   // =========================================================================
   // 1. ユーザー
   //
-  // ┌─────────────┬────────┬──────────────────────────────────────────┐
-  // │ 氏名        │ ロール │ 概要                                     │
-  // ├─────────────┼────────┼──────────────────────────────────────────┤
-  // │ 土井垣将    │ admin  │ 自己評価なし。評価アサインなし           │
-  // │ 不知火守    │ admin  │ 2025のみ自己評価あり。上長: 土井垣       │
-  // │ 山田太郎    │ member │ 通年自己評価あり。上長: 土井垣（通年）   │
-  // │             │        │                 不知火（2026〜）         │
-  // │ 里中智      │ member │ 通年自己評価あり。上長: 不知火・山田     │
-  // │ 岩鬼正美    │ member │ 通年自己評価なし。評価アサインなし       │
-  // └─────────────┴────────┴──────────────────────────────────────────┘
+  // ┌──────────────────────────┬────────┬──────────┬───────────────────────────────────────────────┐
+  // │ email                    │ role   │ isActive │ 概要                                          │
+  // ├──────────────────────────┼────────┼──────────┼───────────────────────────────────────────────┤
+  // │ bonjiri@example.com      │ ADMIN  │ true     │ 自己評価なし・評価アサインなし（管理操作確認用）│
+  // │ tsukune@example.com      │ ADMIN  │ true     │ 2025のみ自己評価あり・上長: bonjiri            │
+  // │ tebasaki@example.com     │ MEMBER │ true     │ 通年自己評価あり・上長: bonjiri（通年）        │
+  // │                          │        │          │                       tsukune（2026〜）        │
+  // │ nankotsu@example.com     │ MEMBER │ true     │ 通年自己評価あり・上長: tsukune・tebasaki      │
+  // │ sunagimo@example.com     │ MEMBER │ false    │ 無効化ユーザー（auth-error テスト用）          │
+  // │ torikawa@example.com     │ MEMBER │ true     │ 評価なし・アサインなし（削除テスト用）         │
+  // └──────────────────────────┴────────┴──────────┴───────────────────────────────────────────────┘
+  //
+  // 共通パスワード: Yakitori2026
   // =========================================================================
   const usersData = [
-    { email: "doigaki@example.com", name: "土井垣将", role: "ADMIN" as const },
-    { email: "shiranui@example.com", name: "不知火守", role: "ADMIN" as const },
-    { email: "yamada@example.com", name: "山田太郎", role: "MEMBER" as const },
-    { email: "satonaka@example.com", name: "里中智", role: "MEMBER" as const },
-    { email: "iwaki@example.com", name: "岩鬼正美", role: "MEMBER" as const },
+    { email: "bonjiri@example.com",  name: "bonjiri",  role: "ADMIN"  as const, isActive: true  },
+    { email: "tsukune@example.com",  name: "tsukune",  role: "ADMIN"  as const, isActive: true  },
+    { email: "tebasaki@example.com", name: "tebasaki", role: "MEMBER" as const, isActive: true  },
+    { email: "nankotsu@example.com", name: "nankotsu", role: "MEMBER" as const, isActive: true  },
+    { email: "sunagimo@example.com", name: "sunagimo", role: "MEMBER" as const, isActive: false },
+    { email: "torikawa@example.com", name: "torikawa", role: "MEMBER" as const, isActive: true  },
   ];
 
   const u: Record<string, { id: string }> = {};
@@ -107,11 +122,12 @@ async function main() {
     const clerkId = await syncClerkUser(data.email);
     const user = await prisma.user.upsert({
       where: { email: data.email },
-      update: { name: data.name, role: data.role, ...(clerkId ? { clerkId } : {}) },
+      update: { name: data.name, role: data.role, isActive: data.isActive, ...(clerkId ? { clerkId } : {}) },
       create: {
         email: data.email,
         name: data.name,
         role: data.role,
+        isActive: data.isActive,
         ...(clerkId ? { clerkId } : {}),
       },
     });
@@ -143,20 +159,21 @@ async function main() {
   //
   //              │ 2025  │ 2026  │ 2027
   //  ────────────┼───────┼───────┼──────
-  //  土井垣将    │ false │ false │ false  ← デフォルトのため登録不要
-  //  不知火守    │ true  │ false │ false  ← 2025 のみ登録
-  //  山田太郎    │ true  │ true  │ true
-  //  里中智      │ true  │ true  │ true
-  //  岩鬼正美    │ false │ false │ false  ← デフォルトのため登録不要
+  //  bonjiri     │ false │ false │ false  ← デフォルトのため登録不要
+  //  tsukune     │ true  │ false │ false  ← 2025 のみ登録
+  //  tebasaki    │ true  │ true  │ true
+  //  nankotsu    │ true  │ true  │ true
+  //  sunagimo    │ false │ false │ false  ← デフォルトのため登録不要
+  //  torikawa    │ false │ false │ false  ← デフォルトのため登録不要
   // =========================================================================
   const settingsData: { email: string; fiscalYear: number; selfEvaluationEnabled: boolean }[] = [
-    { email: "shiranui@example.com", fiscalYear: 2025, selfEvaluationEnabled: true },
-    { email: "yamada@example.com", fiscalYear: 2025, selfEvaluationEnabled: true },
-    { email: "yamada@example.com", fiscalYear: 2026, selfEvaluationEnabled: true },
-    { email: "yamada@example.com", fiscalYear: 2027, selfEvaluationEnabled: true },
-    { email: "satonaka@example.com", fiscalYear: 2025, selfEvaluationEnabled: true },
-    { email: "satonaka@example.com", fiscalYear: 2026, selfEvaluationEnabled: true },
-    { email: "satonaka@example.com", fiscalYear: 2027, selfEvaluationEnabled: true },
+    { email: "tsukune@example.com",  fiscalYear: 2025, selfEvaluationEnabled: true },
+    { email: "tebasaki@example.com", fiscalYear: 2025, selfEvaluationEnabled: true },
+    { email: "tebasaki@example.com", fiscalYear: 2026, selfEvaluationEnabled: true },
+    { email: "tebasaki@example.com", fiscalYear: 2027, selfEvaluationEnabled: true },
+    { email: "nankotsu@example.com", fiscalYear: 2025, selfEvaluationEnabled: true },
+    { email: "nankotsu@example.com", fiscalYear: 2026, selfEvaluationEnabled: true },
+    { email: "nankotsu@example.com", fiscalYear: 2027, selfEvaluationEnabled: true },
   ];
 
   for (const s of settingsData) {
@@ -177,26 +194,26 @@ async function main() {
   //
   //  年度  │ 被評価者  │ 評価者（上長）
   //  ──────┼───────────┼────────────────
-  //  2025  │ 不知火守  │ 土井垣将
-  //  2025  │ 山田太郎  │ 土井垣将
-  //  2025  │ 里中智    │ 不知火守
-  //  2025  │ 里中智    │ 山田太郎
-  //  2026  │ 山田太郎  │ 土井垣将
-  //  2026  │ 山田太郎  │ 不知火守
-  //  2026  │ 里中智    │ 不知火守
-  //  2026  │ 里中智    │ 山田太郎
+  //  2025  │ tsukune   │ bonjiri
+  //  2025  │ tebasaki  │ bonjiri
+  //  2025  │ nankotsu  │ tsukune
+  //  2025  │ nankotsu  │ tebasaki
+  //  2026  │ tebasaki  │ bonjiri
+  //  2026  │ tebasaki  │ tsukune
+  //  2026  │ nankotsu  │ tsukune
+  //  2026  │ nankotsu  │ tebasaki
   // =========================================================================
   const assignmentsData = [
     // 2025
-    { fiscalYear: 2025, evaluatee: "shiranui@example.com", evaluator: "doigaki@example.com" },
-    { fiscalYear: 2025, evaluatee: "yamada@example.com", evaluator: "doigaki@example.com" },
-    { fiscalYear: 2025, evaluatee: "satonaka@example.com", evaluator: "shiranui@example.com" },
-    { fiscalYear: 2025, evaluatee: "satonaka@example.com", evaluator: "yamada@example.com" },
+    { fiscalYear: 2025, evaluatee: "tsukune@example.com",  evaluator: "bonjiri@example.com"  },
+    { fiscalYear: 2025, evaluatee: "tebasaki@example.com", evaluator: "bonjiri@example.com"  },
+    { fiscalYear: 2025, evaluatee: "nankotsu@example.com", evaluator: "tsukune@example.com"  },
+    { fiscalYear: 2025, evaluatee: "nankotsu@example.com", evaluator: "tebasaki@example.com" },
     // 2026
-    { fiscalYear: 2026, evaluatee: "yamada@example.com", evaluator: "doigaki@example.com" },
-    { fiscalYear: 2026, evaluatee: "yamada@example.com", evaluator: "shiranui@example.com" },
-    { fiscalYear: 2026, evaluatee: "satonaka@example.com", evaluator: "shiranui@example.com" },
-    { fiscalYear: 2026, evaluatee: "satonaka@example.com", evaluator: "yamada@example.com" },
+    { fiscalYear: 2026, evaluatee: "tebasaki@example.com", evaluator: "bonjiri@example.com"  },
+    { fiscalYear: 2026, evaluatee: "tebasaki@example.com", evaluator: "tsukune@example.com"  },
+    { fiscalYear: 2026, evaluatee: "nankotsu@example.com", evaluator: "tsukune@example.com"  },
+    { fiscalYear: 2026, evaluatee: "nankotsu@example.com", evaluator: "tebasaki@example.com" },
   ];
 
   for (const a of assignmentsData) {
@@ -298,6 +315,64 @@ async function main() {
   // =========================================================================
   const allItems = await prisma.evaluationItem.findMany({ select: { id: true } });
   await seedFiscalYearItems(allItems.map((i) => i.id));
+
+  // =========================================================================
+  // 9. 評価データ（evaluations）
+  //    「採点欄は表示されるが編集不可」シナリオの表示確認用に事前データを投入する
+  //
+  //  tebasaki（2026年度）: 先頭3件に self_score + manager_score を設定
+  //    → 自己評価画面で評価者採点欄が表示・編集不可であることを確認できる
+  //  nankotsu（2026年度）: 先頭3件に self_score のみ設定
+  //    → 評価者画面で自己採点欄が表示・編集不可であることを確認できる
+  // =========================================================================
+  const seedItems = allItems.slice(0, 3);
+
+  const evaluationsData: {
+    fiscalYear: number;
+    evaluateeEmail: string;
+    itemId: number;
+    selfScore: "ka" | "ryo" | "yu" | null;
+    selfReason: string | null;
+    managerScore: "ka" | "ryo" | "yu" | null;
+    managerReason: string | null;
+  }[] = [
+    // tebasaki: 自己採点 + 評価者採点あり
+    { fiscalYear: 2026, evaluateeEmail: "tebasaki@example.com", itemId: seedItems[0].id, selfScore: "ryo",  selfReason: "積極的に取り組みました",  managerScore: "yu",  managerReason: "非常に優秀な取り組みでした" },
+    { fiscalYear: 2026, evaluateeEmail: "tebasaki@example.com", itemId: seedItems[1].id, selfScore: "ka",   selfReason: "改善の余地があります",       managerScore: "ryo", managerReason: "着実に成長しています"           },
+    { fiscalYear: 2026, evaluateeEmail: "tebasaki@example.com", itemId: seedItems[2].id, selfScore: "yu",   selfReason: "目標を超えて達成できました", managerScore: "yu",  managerReason: "期待以上の成果でした"           },
+    // nankotsu: 自己採点のみ（評価者採点なし）
+    { fiscalYear: 2026, evaluateeEmail: "nankotsu@example.com", itemId: seedItems[0].id, selfScore: "ka",   selfReason: "基本的なことはできました",   managerScore: null,  managerReason: null },
+    { fiscalYear: 2026, evaluateeEmail: "nankotsu@example.com", itemId: seedItems[1].id, selfScore: "ryo",  selfReason: "しっかり対応できました",     managerScore: null,  managerReason: null },
+    { fiscalYear: 2026, evaluateeEmail: "nankotsu@example.com", itemId: seedItems[2].id, selfScore: "ryo",  selfReason: "チームに貢献できました",     managerScore: null,  managerReason: null },
+  ];
+
+  for (const e of evaluationsData) {
+    await prisma.evaluation.upsert({
+      where: {
+        fiscalYear_evaluateeId_evalItemId: {
+          fiscalYear: e.fiscalYear,
+          evaluateeId: u[e.evaluateeEmail].id,
+          evalItemId: e.itemId,
+        },
+      },
+      update: {
+        selfScore: e.selfScore,
+        selfReason: e.selfReason,
+        managerScore: e.managerScore,
+        managerReason: e.managerReason,
+      },
+      create: {
+        fiscalYear: e.fiscalYear,
+        evaluateeId: u[e.evaluateeEmail].id,
+        evalItemId: e.itemId,
+        selfScore: e.selfScore,
+        selfReason: e.selfReason,
+        managerScore: e.managerScore,
+        managerReason: e.managerReason,
+      },
+    });
+  }
+  console.log(`evaluations: ${evaluationsData.length} upserted`);
 }
 
 main()


### PR DESCRIPTION
## Summary

- ユーザーを link-hub / daily-hub と統一（bonjiri / tsukune / tebasaki / nankotsu / sunagimo / torikawa）
- 共通パスワードを `Yakitori2026` に統一
- E2E シナリオを全カバーするデータを追加（inactive ユーザー・評価データ）

## 変更内容

### ユーザー構成

| email | role | isActive | 用途 |
|-------|------|----------|------|
| bonjiri@example.com | ADMIN | ✅ | 管理操作確認用・アサインなし |
| tsukune@example.com | ADMIN | ✅ | 2025のみ自己評価・上長: bonjiri |
| tebasaki@example.com | MEMBER | ✅ | 通年自己評価・採点データあり |
| nankotsu@example.com | MEMBER | ✅ | 通年自己評価・複数上長 |
| sunagimo@example.com | MEMBER | ❌ | auth-error リダイレクトテスト専用 |
| torikawa@example.com | MEMBER | ✅ | 削除テスト専用（関連データなし）|

### 追加データ
- `evaluations`: tebasaki（self+manager）・nankotsu（selfのみ）の 2026年度 先頭3件
- 旧ユーザー（doigaki/shiranui/yamada/satonaka/iwaki）のクリーンアップ追加

### ドキュメント更新
- `docs/testing.md`: テストユーザー表・投入データ表を更新
- `docs/development.md`: ユーザー表・パスワードを更新

## Test plan

- [x] `npx prisma db seed` が正常完了することを確認（6 users / 8 assignments / 6 evaluations upserted）
- [ ] `MOCK_USER_EMAIL=bonjiri@example.com` でログインし管理画面が表示されることを確認
- [ ] `MOCK_USER_EMAIL=tebasaki@example.com` でログインし自己評価画面の採点データが表示されることを確認
- [ ] `MOCK_USER_EMAIL=sunagimo@example.com` でログインし `/auth-error` にリダイレクトされることを確認

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)