### PR TITLE
fix: T130 /auth-error ページのエラーメッセージ修正

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -2,6 +2,7 @@ import { SignOutButton } from "@clerk/nextjs";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
 import { NavLinks } from "@/components/NavLinks";
 import { APP_NAME } from "@/lib/constants";
 
@@ -13,8 +14,16 @@ export default async function DashboardLayout({
   const session = await getSession();
   if (!session) {
     const { userId } = await auth();
-    // Clerk セッションはあるが DB セッションが取得できない場合は競合エラーページへ
-    if (userId) redirect("/auth-error");
+    if (userId) {
+      // isActive=false のユーザーは専用メッセージページへ
+      const user = await prisma.user.findUnique({
+        where: { clerkId: userId },
+        select: { isActive: true },
+      });
+      if (user && !user.isActive) redirect("/auth-error?reason=inactive");
+      // それ以外（Clerk ID 競合など）は汎用エラーページへ
+      redirect("/auth-error");
+    }
     redirect("/login");
   }
 

--- a/src/app/auth-error/page.tsx
+++ b/src/app/auth-error/page.tsx
@@ -1,12 +1,13 @@
 import { SignOutButton } from "@clerk/nextjs";
 
 type Props = {
-  searchParams: Promise<{ reason?: string }>;
+  searchParams: Promise<{ reason?: string | string[] }>;
 };
 
 export default async function AuthErrorPage({ searchParams }: Props) {
   const { reason } = await searchParams;
-  const isInactive = reason === "inactive";
+  const normalizedReason = Array.isArray(reason) ? reason[0] : reason;
+  const isInactive = normalizedReason === "inactive";
 
   const message = isInactive
     ? "アカウントが無効化されています。管理者にお問い合わせください。"

--- a/src/app/auth-error/page.tsx
+++ b/src/app/auth-error/page.tsx
@@ -1,15 +1,22 @@
 import { SignOutButton } from "@clerk/nextjs";
 
-export default function AuthErrorPage() {
+type Props = {
+  searchParams: Promise<{ reason?: string }>;
+};
+
+export default async function AuthErrorPage({ searchParams }: Props) {
+  const { reason } = await searchParams;
+  const isInactive = reason === "inactive";
+
+  const message = isInactive
+    ? "アカウントが無効化されています。管理者にお問い合わせください。"
+    : "このアカウントはすでに別のユーザーに紐付けられています。一度サインアウトして、正しいアカウントでログインしてください。";
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50">
       <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-sm text-center">
         <h1 className="text-lg font-semibold text-gray-900 mb-2">ログインできません</h1>
-        <p className="text-sm text-gray-600 mb-6">
-          このアカウントはすでに別のユーザーに紐付けられています。
-          <br />
-          一度サインアウトして、正しいアカウントでログインしてください。
-        </p>
+        <p className="text-sm text-gray-600 mb-6">{message}</p>
         <SignOutButton redirectUrl="/login">
           <button
             type="button"


### PR DESCRIPTION
## Summary

- `isActive=false` ユーザーがリダイレクトされた際に誤ったメッセージが表示されていたバグを修正
- エラー原因別にメッセージを出し分けるよう対応

## 変更内容

### `src/app/(dashboard)/layout.tsx`
- `getSession()` が null を返し Clerk セッションが存在する場合、DB でユーザーの `isActive` を確認
- `isActive=false` なら `/auth-error?reason=inactive` へリダイレクト
- それ以外（Clerk ID 競合等）は従来通り `/auth-error` へリダイレクト

### `src/app/auth-error/page.tsx`
- `searchParams` の `reason` を読み取りメッセージを切り替え
  - `reason=inactive` → 「アカウントが無効化されています。管理者にお問い合わせください。」
  - それ以外 → 「このアカウントはすでに別のユーザーに紐付けられています。」

## Test plan

- [ ] `sunagimo@example.com`（`isActive=false`）でログイン → `/auth-error?reason=inactive` にリダイレクトされ「アカウントが無効化されています。」が表示される
- [ ] 競合ケースでは従来通りのメッセージが表示される

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)