### PR TITLE
fix: マージ時に混入した lint エラーを修正

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -312,6 +312,8 @@ async function main() {
   );
 
   for (const item of evaluationItemsData) {
+    const target = targetByName[item.target];
+    const category = categoryByKey[categoryKey(item.target, item.category)];
     await prisma.evaluationItem.upsert({
       where: { categoryId_no: { categoryId: category.id, no: item.item_no } },
       update: {

--- a/src/app/api/members/[id]/evaluations/[year]/[uid]/route.ts
+++ b/src/app/api/members/[id]/evaluations/[year]/[uid]/route.ts
@@ -11,7 +11,7 @@ export async function PUT(
     return errorResponse("UNAUTHORIZED", "認証が必要です", 401);
   }
 
-  const { id: evaluateeId, year, uid: evalUid } = await params;
+  const { id: evaluateeId, year, uid: _evalUid } = await params;
   const fiscalYear = Number(year);
   if (Number.isNaN(fiscalYear)) {
     return errorResponse("BAD_REQUEST", "year は数値で指定してください", 400);


### PR DESCRIPTION
## Summary
- `prisma/seed.ts`: マージ時に脱落した `target` / `category` 変数参照を復元
- `src/app/api/members/[id]/evaluations/[year]/[uid]/route.ts`: 未使用変数 `evalUid` を `_evalUid` にリネーム（Biome 規約）

## 背景
PR #144 (develop → master) のマージ時に上記 lint エラーが混入。  
GitHub Actions run [#24002943793](https://github.com/ot-nemoto/eval-hub/actions/runs/24002943793) で検出。

## Test plan
- [ ] CI (Lint) が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)