### PR TITLE
fix: admin ナビに年度管理・マスタ管理・評価項目管理のリンクを追加 [T136]

### DIFF
--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -8,7 +8,12 @@ const memberLinks = [
   { href: "/members", label: "社員一覧" },
 ];
 
-const adminLinks = [{ href: "/admin/users", label: "ユーザー管理" }];
+const adminLinks = [
+  { href: "/admin/users", label: "ユーザー管理" },
+  { href: "/admin/targets", label: "マスタ管理" },
+  { href: "/admin/evaluation-items", label: "評価項目管理" },
+  { href: "/admin/fiscal-years", label: "年度管理" },
+];
 
 type Props = { role: "ADMIN" | "MEMBER" };
 


### PR DESCRIPTION
## 概要

`NavLinks.tsx` の admin メニューに `/admin/targets`・`/admin/evaluation-items`・`/admin/fiscal-years` へのリンクを追加。

Closes #148

## 変更内容

- `src/components/NavLinks.tsx` — `adminLinks` に以下3件を追加
  - マスタ管理（`/admin/targets`）
  - 評価項目管理（`/admin/evaluation-items`）
  - 年度管理（`/admin/fiscal-years`）

## 動作確認

- admin ユーザーのナビに3リンクが表示されること ✅
- 各リンクをクリックして正しく遷移・アクティブ表示されること ✅
- member ユーザーのナビには表示されないこと ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)