### PR TITLE
fix: 未アサインメンバーの評価ページ直アクセス時のレスポンスを redirect に統一 [T137]

### DIFF
--- a/src/app/(dashboard)/members/[id]/evaluations/page.tsx
+++ b/src/app/(dashboard)/members/[id]/evaluations/page.tsx
@@ -27,7 +27,7 @@ export default async function MemberEvaluationsPage({ params }: Props) {
         },
       },
     });
-    if (!assignment) notFound();
+    if (!assignment) redirect("/members");
   }
 
   const evaluatee = await prisma.user.findUnique({


### PR DESCRIPTION
## 概要

未アサインメンバーの `/members/[id]/evaluations` に直アクセスした際、`notFound()`（404）を返していたのを `redirect('/members')` に変更。

Closes #149

## 変更内容

- `src/app/(dashboard)/members/[id]/evaluations/page.tsx`
  - アサイン未確認時の `notFound()` → `redirect("/members")`

## 動作確認

- 未アサインメンバーの評価ページに直アクセス → `/members` にリダイレクト ✅
- アサイン済みメンバーの評価ページは正常表示 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)