### PR TITLE
feat: lib/errors.ts の作成（カスタムエラークラス）[T138]

### DIFF
--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "./errors";
 

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "./errors";
+
+describe("NotFoundError", () => {
+  it("デフォルトメッセージで生成できる", () => {
+    const error = new NotFoundError();
+    expect(error.message).toBe("Not found");
+    expect(error.name).toBe("NotFoundError");
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it("カスタムメッセージで生成できる", () => {
+    const error = new NotFoundError("ユーザーが見つかりません");
+    expect(error.message).toBe("ユーザーが見つかりません");
+    expect(error.name).toBe("NotFoundError");
+  });
+});
+
+describe("ForbiddenError", () => {
+  it("デフォルトメッセージで生成できる", () => {
+    const error = new ForbiddenError();
+    expect(error.message).toBe("Forbidden");
+    expect(error.name).toBe("ForbiddenError");
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it("カスタムメッセージで生成できる", () => {
+    const error = new ForbiddenError("権限がありません");
+    expect(error.message).toBe("権限がありません");
+    expect(error.name).toBe("ForbiddenError");
+  });
+});
+
+describe("ConflictError", () => {
+  it("デフォルトメッセージで生成できる", () => {
+    const error = new ConflictError();
+    expect(error.message).toBe("Conflict");
+    expect(error.name).toBe("ConflictError");
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it("カスタムメッセージで生成できる", () => {
+    const error = new ConflictError("紐づくデータが存在するため削除できません");
+    expect(error.message).toBe("紐づくデータが存在するため削除できません");
+    expect(error.name).toBe("ConflictError");
+  });
+});
+
+describe("BadRequestError", () => {
+  it("デフォルトメッセージで生成できる", () => {
+    const error = new BadRequestError();
+    expect(error.message).toBe("Bad request");
+    expect(error.name).toBe("BadRequestError");
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it("カスタムメッセージで生成できる", () => {
+    const error = new BadRequestError("入力値が不正です");
+    expect(error.message).toBe("入力値が不正です");
+    expect(error.name).toBe("BadRequestError");
+  });
+});

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -8,6 +8,7 @@ describe("NotFoundError", () => {
     expect(error.message).toBe("Not found");
     expect(error.name).toBe("NotFoundError");
     expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(NotFoundError);
   });
 
   it("カスタムメッセージで生成できる", () => {
@@ -23,6 +24,7 @@ describe("ForbiddenError", () => {
     expect(error.message).toBe("Forbidden");
     expect(error.name).toBe("ForbiddenError");
     expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(ForbiddenError);
   });
 
   it("カスタムメッセージで生成できる", () => {
@@ -38,6 +40,7 @@ describe("ConflictError", () => {
     expect(error.message).toBe("Conflict");
     expect(error.name).toBe("ConflictError");
     expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(ConflictError);
   });
 
   it("カスタムメッセージで生成できる", () => {
@@ -53,6 +56,7 @@ describe("BadRequestError", () => {
     expect(error.message).toBe("Bad request");
     expect(error.name).toBe("BadRequestError");
     expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(BadRequestError);
   });
 
   it("カスタムメッセージで生成できる", () => {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,27 @@
+export class NotFoundError extends Error {
+  constructor(message = "Not found") {
+    super(message);
+    this.name = "NotFoundError";
+  }
+}
+
+export class ForbiddenError extends Error {
+  constructor(message = "Forbidden") {
+    super(message);
+    this.name = "ForbiddenError";
+  }
+}
+
+export class ConflictError extends Error {
+  constructor(message = "Conflict") {
+    super(message);
+    this.name = "ConflictError";
+  }
+}
+
+export class BadRequestError extends Error {
+  constructor(message = "Bad request") {
+    super(message);
+    this.name = "BadRequestError";
+  }
+}


### PR DESCRIPTION
## 概要

Server Actions 移行で使用するカスタムエラークラスを `src/lib/errors.ts` に作成。

Closes #156

## 変更内容

- `src/lib/errors.ts` — 4クラスを定義
  - `NotFoundError` — リソースが存在しない
  - `ForbiddenError` — 権限不足
  - `ConflictError` — 競合（重複・依存関係あり削除）
  - `BadRequestError` — 不正な入力値
- `src/lib/errors.test.ts` — 8テスト（全 Pass ✅）

## 確認済み

- `npm test -- src/lib/errors.test.ts`：8 tests passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)