### PR TITLE
[T155] 年度管理画面の削除ボタンを紐づきデータがある場合に非活性化

### DIFF
--- a/src/app/(dashboard)/admin/fiscal-years/page.tsx
+++ b/src/app/(dashboard)/admin/fiscal-years/page.tsx
@@ -81,12 +81,7 @@ export default async function FiscalYearsPage() {
                   <td className="px-4 py-3 text-right">
                     <FiscalYearActions
                       fiscalYear={fy}
-                      isDeletable={
-                        fy._count.fiscalYearItems === 0 &&
-                        fy._count.evaluationSettings === 0 &&
-                        fy._count.evaluationAssignments === 0 &&
-                        fy._count.evaluations === 0
-                      }
+                      isDeletable={Object.values(fy._count).every((count) => count === 0)}
                     />
                   </td>
                 </tr>

--- a/src/app/(dashboard)/admin/fiscal-years/page.tsx
+++ b/src/app/(dashboard)/admin/fiscal-years/page.tsx
@@ -11,7 +11,21 @@ export default async function FiscalYearsPage() {
 
   const fiscalYears = await prisma.fiscalYear.findMany({
     orderBy: { year: "desc" },
-    select: { year: true, name: true, startDate: true, endDate: true, isCurrent: true },
+    select: {
+      year: true,
+      name: true,
+      startDate: true,
+      endDate: true,
+      isCurrent: true,
+      _count: {
+        select: {
+          fiscalYearItems: true,
+          evaluationSettings: true,
+          evaluationAssignments: true,
+          evaluations: true,
+        },
+      },
+    },
   });
 
   return (
@@ -65,7 +79,15 @@ export default async function FiscalYearsPage() {
                     )}
                   </td>
                   <td className="px-4 py-3 text-right">
-                    <FiscalYearActions fiscalYear={fy} />
+                    <FiscalYearActions
+                      fiscalYear={fy}
+                      isDeletable={
+                        fy._count.fiscalYearItems === 0 &&
+                        fy._count.evaluationSettings === 0 &&
+                        fy._count.evaluationAssignments === 0 &&
+                        fy._count.evaluations === 0
+                      }
+                    />
                   </td>
                 </tr>
               ))

--- a/src/components/admin/FiscalYearActions.tsx
+++ b/src/components/admin/FiscalYearActions.tsx
@@ -16,9 +16,9 @@ type FiscalYear = {
   isCurrent: boolean;
 };
 
-type Props = { fiscalYear: FiscalYear };
+type Props = { fiscalYear: FiscalYear; isDeletable: boolean };
 
-export function FiscalYearActions({ fiscalYear }: Props) {
+export function FiscalYearActions({ fiscalYear, isDeletable }: Props) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [editing, setEditing] = useState(false);
@@ -147,8 +147,9 @@ export function FiscalYearActions({ fiscalYear }: Props) {
       <button
         type="button"
         onClick={handleDelete}
-        disabled={loading}
-        className="rounded border border-red-300 px-2 py-1 text-xs text-red-600 hover:bg-red-50 disabled:opacity-50"
+        disabled={loading || !isDeletable}
+        title={!isDeletable ? "紐づくデータが存在するため削除できません" : undefined}
+        className="rounded border border-red-300 px-2 py-1 text-xs text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
       >
         削除
       </button>


### PR DESCRIPTION
## 概要
- 年度一覧取得時に Prisma `_count` で紐づきレコード数（評価項目・評価設定・評価者アサイン・評価）をサーバーサイドで取得
- 1件以上存在する場合、`FiscalYearActions` の削除ボタンを `disabled` にする
- ホバー時にツールチップ「紐づくデータが存在するため削除できません」を表示

## 変更ファイル
- `src/app/(dashboard)/admin/fiscal-years/page.tsx` — `_count` を `select` に追加し `isDeletable` を算出して props に渡す
- `src/components/admin/FiscalYearActions.tsx` — `isDeletable` props を追加、削除ボタンの `disabled` 制御とツールチップを追加

## 動作確認
- 紐づきデータが存在する年度の削除ボタンが非活性になることを手動確認済み

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)