### PR TITLE
[T156] ユーザー管理画面の削除ボタンを紐づきデータがある場合に非活性化

### DIFF
--- a/src/app/(dashboard)/admin/users/page.tsx
+++ b/src/app/(dashboard)/admin/users/page.tsx
@@ -2,14 +2,34 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { UserActions } from "@/components/admin/UserActions";
 import { getSession } from "@/lib/auth";
-import { getUsers } from "@/lib/users";
+import { prisma } from "@/lib/prisma";
 
 export default async function AdminUsersPage() {
   const session = await getSession();
   if (!session) redirect("/login");
   if (session.user.role !== "ADMIN") redirect("/evaluations");
 
-  const users = await getUsers();
+  const users = await prisma.user.findMany({
+    orderBy: { name: "asc" },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      role: true,
+      division: true,
+      joinedAt: true,
+      createdAt: true,
+      isActive: true,
+      _count: {
+        select: {
+          evaluateeAssignments: true,
+          evaluatorAssignments: true,
+          evaluations: true,
+          evaluationSettings: true,
+        },
+      },
+    },
+  });
 
   return (
     <div>
@@ -68,6 +88,7 @@ export default async function AdminUsersPage() {
                     currentRole={user.role}
                     isActive={user.isActive}
                     isSelf={user.id === session.user.id}
+                    isDeletable={Object.values(user._count).every((count) => count === 0)}
                   />
                 </td>
               </tr>

--- a/src/components/admin/UserActions.tsx
+++ b/src/components/admin/UserActions.tsx
@@ -9,9 +9,10 @@ type Props = {
   currentRole: "ADMIN" | "MEMBER";
   isActive: boolean;
   isSelf: boolean;
+  isDeletable: boolean;
 };
 
-export function UserActions({ userId, currentRole, isActive, isSelf }: Props) {
+export function UserActions({ userId, currentRole, isActive, isSelf, isDeletable }: Props) {
   const [loading, setLoading] = useState(false);
 
   async function handleRoleChange() {
@@ -88,8 +89,9 @@ export function UserActions({ userId, currentRole, isActive, isSelf }: Props) {
       <button
         type="button"
         onClick={handleDelete}
-        disabled={loading}
-        className="rounded border border-red-300 px-2 py-1 text-xs text-red-600 hover:bg-red-50 disabled:opacity-50"
+        disabled={loading || !isDeletable}
+        title={!isDeletable ? "評価データまたはアサインデータが存在するため削除できません" : undefined}
+        className="rounded border border-red-300 px-2 py-1 text-xs text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
       >
         削除
       </button>


### PR DESCRIPTION
## 概要
- ユーザー一覧取得時に Prisma `_count` で紐づきレコード数（evaluateeAssignments・evaluatorAssignments・evaluations・evaluationSettings）をサーバーサイドで取得
- 1件以上存在する場合、`UserActions` の削除ボタンを `disabled` にする
- ホバー時にツールチップ「評価データまたはアサインデータが存在するため削除できません」を表示
- T155（年度管理）と同じ実装方針

## 変更ファイル
- `src/app/(dashboard)/admin/users/page.tsx` — `getUsers()` を直接 Prisma クエリ（`_count` 付き）に置き換え、`isDeletable` を算出して props に渡す
- `src/components/admin/UserActions.tsx` — `isDeletable` props を追加、削除ボタンの `disabled` 制御とツールチップを追加

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)