### PR TITLE
[T62] 評価者アサイン管理画面（admin）

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -111,6 +111,7 @@
 | 管理：年度管理 | `/admin/fiscal-years` | 年度の追加・編集・削除・現在年度設定 | admin |
 | 管理：ユーザー一覧 | `/admin/users` | ユーザー一覧・有効化/無効化・削除 | admin |
 | 管理：自己評価要否設定 | `/admin/users/[id]/evaluation-settings` | ユーザーごとの年度別自己評価要否設定 | admin |
+| 管理：評価者アサイン管理 | `/admin/evaluation-assignments` | 年度ごとの評価者アサイン登録・削除 | admin |
 
 ---
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -18,6 +18,7 @@
 | 管理：年度管理 | `/admin/fiscal-years` | ヘッダーあり | admin のみ |
 | 管理：ユーザー一覧 | `/admin/users` | ヘッダーあり | admin のみ |
 | 管理：自己評価要否設定 | `/admin/users/[id]/evaluation-settings` | ヘッダーあり | admin のみ |
+| 管理：評価者アサイン管理 | `/admin/evaluation-assignments` | ヘッダーあり | admin のみ |
 
 ### 画面遷移
 

--- a/src/app/(dashboard)/admin/evaluation-assignments/page.tsx
+++ b/src/app/(dashboard)/admin/evaluation-assignments/page.tsx
@@ -1,0 +1,117 @@
+import { redirect } from "next/navigation";
+
+import { EvaluationAssignmentActions } from "@/components/admin/EvaluationAssignmentActions";
+import { EvaluationAssignmentForm } from "@/components/admin/EvaluationAssignmentForm";
+import { EvaluationAssignmentYearSelector } from "@/components/admin/EvaluationAssignmentYearSelector";
+import { getSession } from "@/lib/auth";
+import { getEvaluationAssignments } from "@/lib/evaluation-assignments";
+import { getFiscalYears } from "@/lib/fiscal-years";
+import { prisma } from "@/lib/prisma";
+
+export default async function EvaluationAssignmentsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ year?: string }>;
+}) {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  if (session.user.role !== "ADMIN") redirect("/evaluations");
+
+  const { year: yearParam } = await searchParams;
+
+  const fiscalYears = await getFiscalYears();
+  const currentFiscalYear =
+    fiscalYears.find((fy) => fy.isCurrent) ?? fiscalYears[0] ?? null;
+
+  const selectedYear = yearParam
+    ? Number(yearParam)
+    : (currentFiscalYear?.year ?? null);
+
+  const [assignments, activeUsers] = await Promise.all([
+    selectedYear !== null ? getEvaluationAssignments({ fiscalYear: selectedYear }) : [],
+    prisma.user.findMany({
+      where: { isActive: true },
+      select: { id: true, name: true },
+      orderBy: { name: "asc" },
+    }),
+  ]);
+
+  // 評価データが存在する evaluateeId を取得（削除時警告に使用）
+  const evaluateeIdsWithEvals =
+    selectedYear !== null
+      ? await prisma.evaluation
+          .findMany({
+            where: { fiscalYear: selectedYear },
+            select: { evaluateeId: true },
+            distinct: ["evaluateeId"],
+          })
+          .then((rows) => new Set(rows.map((r) => r.evaluateeId)))
+      : new Set<string>();
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h2 className="text-xl font-bold text-gray-900">評価者アサイン管理</h2>
+        <p className="text-sm text-gray-500">
+          年度ごとに被評価者と評価者の組み合わせを管理します。
+        </p>
+      </div>
+
+      <div className="mb-4 flex items-center gap-4">
+        <EvaluationAssignmentYearSelector
+          fiscalYears={fiscalYears.map((fy) => ({ year: fy.year, name: fy.name }))}
+          selectedYear={selectedYear}
+        />
+      </div>
+
+      {selectedYear !== null && (
+        <div className="mb-6">
+          <EvaluationAssignmentForm fiscalYear={selectedYear} users={activeUsers} />
+        </div>
+      )}
+
+      <div className="overflow-hidden rounded-lg border bg-white">
+        <table className="w-full text-sm">
+          <thead className="border-b bg-gray-50">
+            <tr>
+              <th className="px-4 py-3 text-left font-medium text-gray-700">年度</th>
+              <th className="px-4 py-3 text-left font-medium text-gray-700">被評価者</th>
+              <th className="px-4 py-3 text-left font-medium text-gray-700">評価者</th>
+              <th className="px-4 py-3" />
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {assignments.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-4 py-8 text-center text-gray-500">
+                  {selectedYear !== null
+                    ? "アサインが登録されていません。"
+                    : "年度を選択してください。"}
+                </td>
+              </tr>
+            ) : (
+              assignments.map((a) => (
+                <tr key={a.id} className="hover:bg-gray-50">
+                  <td className="px-4 py-3 text-gray-700">{a.fiscalYear}</td>
+                  <td className="px-4 py-3 font-medium text-gray-900">{a.evaluatee.name}</td>
+                  <td className="px-4 py-3 text-gray-700">{a.evaluator.name}</td>
+                  <td className="px-4 py-3 text-right">
+                    <EvaluationAssignmentActions
+                      id={a.id}
+                      hasEvaluations={evaluateeIdsWithEvals.has(a.evaluatee.id)}
+                      label={`${a.evaluatee.name} ← ${a.evaluator.name}`}
+                    />
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {assignments.length > 0 && (
+        <p className="mt-2 text-xs text-gray-400">{assignments.length} 件</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/admin/evaluation-assignments/page.tsx
+++ b/src/app/(dashboard)/admin/evaluation-assignments/page.tsx
@@ -29,26 +29,23 @@ export default async function EvaluationAssignmentsPage({
       ? parsedYear
       : (currentFiscalYear?.year ?? null);
 
-  const [assignments, activeUsers] = await Promise.all([
+  const [assignments, activeUsers, evaluateeIdsWithEvals] = await Promise.all([
     selectedYear !== null ? getEvaluationAssignments({ fiscalYear: selectedYear }) : [],
     prisma.user.findMany({
       where: { isActive: true },
       select: { id: true, name: true },
       orderBy: { name: "asc" },
     }),
-  ]);
-
-  // 評価データが存在する evaluateeId を取得（削除時警告に使用）
-  const evaluateeIdsWithEvals =
     selectedYear !== null
-      ? await prisma.evaluation
+      ? prisma.evaluation
           .findMany({
             where: { fiscalYear: selectedYear },
             select: { evaluateeId: true },
             distinct: ["evaluateeId"],
           })
           .then((rows) => new Set(rows.map((r) => r.evaluateeId)))
-      : new Set<string>();
+      : new Set<string>(),
+  ]);
 
   return (
     <div>

--- a/src/app/(dashboard)/admin/evaluation-assignments/page.tsx
+++ b/src/app/(dashboard)/admin/evaluation-assignments/page.tsx
@@ -23,9 +23,11 @@ export default async function EvaluationAssignmentsPage({
   const currentFiscalYear =
     fiscalYears.find((fy) => fy.isCurrent) ?? fiscalYears[0] ?? null;
 
-  const selectedYear = yearParam
-    ? Number(yearParam)
-    : (currentFiscalYear?.year ?? null);
+  const parsedYear = yearParam !== undefined ? Number(yearParam) : null;
+  const selectedYear =
+    parsedYear !== null && Number.isInteger(parsedYear)
+      ? parsedYear
+      : (currentFiscalYear?.year ?? null);
 
   const [assignments, activeUsers] = await Promise.all([
     selectedYear !== null ? getEvaluationAssignments({ fiscalYear: selectedYear }) : [],

--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -10,6 +10,7 @@ const memberLinks = [
 
 const adminLinks = [
   { href: "/admin/users", label: "ユーザー管理" },
+  { href: "/admin/evaluation-assignments", label: "アサイン管理" },
   { href: "/admin/targets", label: "マスタ管理" },
   { href: "/admin/evaluation-items", label: "評価項目管理" },
   { href: "/admin/fiscal-years", label: "年度管理" },

--- a/src/components/admin/EvaluationAssignmentActions.tsx
+++ b/src/components/admin/EvaluationAssignmentActions.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { deleteEvaluationAssignmentAction } from "@/app/(dashboard)/admin/evaluation-assignments/actions";
+
+type Props = {
+  id: string;
+  hasEvaluations: boolean;
+  label: string;
+};
+
+export function EvaluationAssignmentActions({ id, hasEvaluations, label }: Props) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  async function handleDelete() {
+    const message = hasEvaluations
+      ? `「${label}」には評価データが存在します。アサインを削除しても評価データは残ります。削除しますか？`
+      : `「${label}」のアサインを削除しますか？`;
+    if (!confirm(message)) return;
+
+    setLoading(true);
+    try {
+      const result = await deleteEvaluationAssignmentAction(id);
+      if (result.error) {
+        alert(result.error);
+      } else {
+        router.refresh();
+      }
+    } catch {
+      alert("通信エラーが発生しました");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleDelete}
+      disabled={loading}
+      className="rounded border border-red-300 px-2 py-1 text-xs text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      削除
+    </button>
+  );
+}

--- a/src/components/admin/EvaluationAssignmentForm.tsx
+++ b/src/components/admin/EvaluationAssignmentForm.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { createEvaluationAssignmentAction } from "@/app/(dashboard)/admin/evaluation-assignments/actions";
+
+type User = { id: string; name: string };
+
+type Props = {
+  fiscalYear: number;
+  users: User[];
+};
+
+export function EvaluationAssignmentForm({ fiscalYear, users }: Props) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [evaluateeId, setEvaluateeId] = useState("");
+  const [evaluatorId, setEvaluatorId] = useState("");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const result = await createEvaluationAssignmentAction({
+        fiscalYear,
+        evaluateeId,
+        evaluatorId,
+      });
+      if (result.error) {
+        alert(result.error);
+      } else {
+        setOpen(false);
+        setEvaluateeId("");
+        setEvaluatorId("");
+        router.refresh();
+      }
+    } catch {
+      alert("通信エラーが発生しました");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="rounded border border-blue-400 px-3 py-1.5 text-sm text-blue-600 hover:bg-blue-50"
+      >
+        ＋ アサインを追加
+      </button>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="rounded-lg border bg-white p-4">
+      <h3 className="mb-4 font-medium text-gray-900">
+        {fiscalYear}年度 — 新しいアサインを追加
+      </h3>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label htmlFor="evaluateeId" className="mb-1 block text-xs font-medium text-gray-700">
+            被評価者
+          </label>
+          <select
+            id="evaluateeId"
+            required
+            value={evaluateeId}
+            onChange={(e) => setEvaluateeId(e.target.value)}
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+          >
+            <option value="">選択してください</option>
+            {users.map((u) => (
+              <option key={u.id} value={u.id}>
+                {u.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="evaluatorId" className="mb-1 block text-xs font-medium text-gray-700">
+            評価者
+          </label>
+          <select
+            id="evaluatorId"
+            required
+            value={evaluatorId}
+            onChange={(e) => setEvaluatorId(e.target.value)}
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+          >
+            <option value="">選択してください</option>
+            {users.map((u) => (
+              <option key={u.id} value={u.id}>
+                {u.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <div className="mt-4 flex gap-2">
+        <button
+          type="submit"
+          disabled={loading}
+          className="rounded bg-blue-600 px-4 py-1.5 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          追加
+        </button>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          disabled={loading}
+          className="rounded border border-gray-300 px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+        >
+          キャンセル
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/admin/EvaluationAssignmentYearSelector.tsx
+++ b/src/components/admin/EvaluationAssignmentYearSelector.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+type FiscalYear = { year: number; name: string };
+
+type Props = {
+  fiscalYears: FiscalYear[];
+  selectedYear: number | null;
+};
+
+export function EvaluationAssignmentYearSelector({ fiscalYears, selectedYear }: Props) {
+  const router = useRouter();
+
+  function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    router.push(`/admin/evaluation-assignments?year=${e.target.value}`);
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <label htmlFor="year-selector" className="text-sm font-medium text-gray-700">
+        年度：
+      </label>
+      <select
+        id="year-selector"
+        value={selectedYear ?? ""}
+        onChange={handleChange}
+        className="rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+      >
+        {fiscalYears.length === 0 && <option value="">年度が登録されていません</option>}
+        {fiscalYears.map((fy) => (
+          <option key={fy.year} value={fy.year}>
+            {fy.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- 年度ごとに評価者アサインを登録・削除できる管理画面 `/admin/evaluation-assignments` を実装
- admin ナビに「アサイン管理」リンクを追加
- 評価データが存在するアサイン削除時は警告ダイアログを表示（削除は可）

## Changes

- `src/app/(dashboard)/admin/evaluation-assignments/page.tsx` — 画面本体（Server Component）
- `src/components/admin/EvaluationAssignmentForm.tsx` — アサイン追加フォーム
- `src/components/admin/EvaluationAssignmentActions.tsx` — 削除ボタン（評価データあり時は警告表示）
- `src/components/admin/EvaluationAssignmentYearSelector.tsx` — 年度セレクター
- `src/components/NavLinks.tsx` — adminLinks に「アサイン管理」を追加
- `docs/requirements.md` / `docs/ui.md` — 画面一覧を更新

## Test plan

- [ ] admin でログイン → ナビの「アサイン管理」から画面に遷移できる
- [ ] 年度セレクターで年度を切り替えるとアサイン一覧が切り替わる
- [ ] アサインを新規追加できる
- [ ] 同一組み合わせの重複追加時にエラーが表示される
- [ ] 評価データのないアサインを削除できる
- [ ] 評価データありのアサインを削除しようとすると警告ダイアログが表示される
- [ ] MEMBER ロールでアクセスすると `/evaluations` にリダイレクトされる

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)