### PR TITLE
[T166] prisma.config.ts の env 読み込み順を修正し .env.example を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="pk_test_..."
 CLERK_SECRET_KEY="sk_test_..."
 NEXT_PUBLIC_CLERK_SIGN_IN_URL=/login
 NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/evaluations
+
+# ローカル開発用認証バイパス（任意）
+# MOCK_USER_ID="<DB の users.id>"
+# MOCK_USER_EMAIL="dev@example.com"

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Database (Neon)
+# Neon コンソール → プロジェクト → Connection string から取得
+DATABASE_URL="postgresql://<user>:<password>@<pooler-host>/<db>?sslmode=require&channel_binding=require"
+DIRECT_URL="postgresql://<user>:<password>@<direct-host>/<db>?sslmode=require&channel_binding=require"
+
+# Clerk
+# Clerk ダッシュボード → API Keys から取得
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="pk_test_..."
+CLERK_SECRET_KEY="sk_test_..."
+NEXT_PUBLIC_CLERK_SIGN_IN_URL=/login
+NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/evaluations

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,8 +33,8 @@ npm run dev
 
 ```env
 # Database（Neon）
-DATABASE_URL="postgresql://<user>:<password>@<pooler-host>/<db>?sslmode=require"
-DIRECT_URL="postgresql://<user>:<password>@<direct-host>/<db>?sslmode=require"
+DATABASE_URL="postgresql://<user>:<password>@<pooler-host>/<db>?sslmode=require&channel_binding=require"
+DIRECT_URL="postgresql://<user>:<password>@<direct-host>/<db>?sslmode=require&channel_binding=require"
 
 # Clerk
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="pk_test_..."

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "prisma/config";
 import * as dotenv from "dotenv";
 
 dotenv.config({ path: ".env" });
+dotenv.config({ path: ".env.local", override: true });
 
 export default defineConfig({
   schema: "prisma/schema.prisma",


### PR DESCRIPTION
## Summary

- `prisma.config.ts` で `.env` → `.env.local`（`override: true`）の順に読み込むよう変更。`.env.local` で staging/develop の切り替えが完結する
- `.env.example` を新規作成し、必要な環境変数のテンプレートをリポジトリに追加
- `.env` を空にする（実際の値は `.env.local` で管理）

## Test plan

- [ ] `.env.local` の Staging セクションのコメントを外すだけで `npx prisma migrate reset` が staging DB に向くことを確認

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)