### PR TITLE
[T53] プロフィール名変更機能を追加

### DIFF
--- a/src/app/(dashboard)/actions.ts
+++ b/src/app/(dashboard)/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth";
 import { FISCAL_YEAR_COOKIE } from "@/lib/fiscal-year";
+import { updateCurrentUserName } from "@/lib/users";
 
 export async function setFiscalYearAction(
   year: number,
@@ -17,6 +18,20 @@ export async function setFiscalYearAction(
 
   const cookieStore = await cookies();
   cookieStore.set(FISCAL_YEAR_COOKIE, String(year), { path: "/" });
+  revalidatePath("/", "layout");
+  return {};
+}
+
+export async function updateNameAction(name: string): Promise<{ error?: string }> {
+  const session = await getSession();
+  if (!session) redirect("/login");
+
+  try {
+    await updateCurrentUserName(session.user.id, name);
+  } catch {
+    return { error: "名前の更新に失敗しました" };
+  }
+
   revalidatePath("/", "layout");
   return {};
 }

--- a/src/app/(dashboard)/actions.ts
+++ b/src/app/(dashboard)/actions.ts
@@ -5,7 +5,7 @@ import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth";
 import { FISCAL_YEAR_COOKIE } from "@/lib/fiscal-year";
 import { BadRequestError } from "@/lib/errors";
-import { updateCurrentUserName } from "@/lib/users";
+import { updateUserName } from "@/lib/users";
 
 export async function setFiscalYearAction(
   year: number,
@@ -28,7 +28,7 @@ export async function updateNameAction(name: string): Promise<{ error?: string }
   if (!session) redirect("/login");
 
   try {
-    await updateCurrentUserName(session.user.id, name);
+    await updateUserName(session.user.id, name);
   } catch (e) {
     if (e instanceof BadRequestError) return { error: e.message };
     throw e;

--- a/src/app/(dashboard)/actions.ts
+++ b/src/app/(dashboard)/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth";
 import { FISCAL_YEAR_COOKIE } from "@/lib/fiscal-year";
+import { BadRequestError } from "@/lib/errors";
 import { updateCurrentUserName } from "@/lib/users";
 
 export async function setFiscalYearAction(
@@ -28,8 +29,9 @@ export async function updateNameAction(name: string): Promise<{ error?: string }
 
   try {
     await updateCurrentUserName(session.user.id, name);
-  } catch {
-    return { error: "名前の更新に失敗しました" };
+  } catch (e) {
+    if (e instanceof BadRequestError) return { error: e.message };
+    throw e;
   }
 
   revalidatePath("/", "layout");

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { FiscalYearSelector } from "@/components/FiscalYearSelector";
 import { LogoutButton } from "@/components/LogoutButton";
 import { NavLinks } from "@/components/NavLinks";
+import { ProfileNameEditor } from "@/components/ProfileNameEditor";
 import { getSession } from "@/lib/auth";
 import { APP_NAME } from "@/lib/constants";
 import { getCurrentFiscalYear } from "@/lib/fiscal-year";
@@ -38,7 +39,7 @@ export default async function DashboardLayout({ children }: { children: React.Re
           </div>
           <div className="flex items-center gap-4">
             <FiscalYearSelector years={years} currentYear={currentYear} />
-            <span className="text-sm text-gray-600">{session.user.name}</span>
+            <ProfileNameEditor name={session.user.name} />
             <LogoutButton />
           </div>
         </div>

--- a/src/components/ProfileNameEditor.tsx
+++ b/src/components/ProfileNameEditor.tsx
@@ -65,6 +65,7 @@ export function ProfileNameEditor({ name }: { name: string }) {
         value={value}
         onChange={(e) => setValue(e.target.value)}
         onKeyDown={handleKeyDown}
+        aria-label="プロフィール名"
         disabled={isPending}
         className="rounded border border-gray-300 px-2 py-0.5 text-sm text-gray-900 focus:border-blue-500 focus:outline-none"
         style={{ width: `${Math.max(value.length, 4) + 4}ch` }}

--- a/src/components/ProfileNameEditor.tsx
+++ b/src/components/ProfileNameEditor.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useRef, useState, useTransition } from "react";
+import { updateNameAction } from "@/app/(dashboard)/actions";
+
+export function ProfileNameEditor({ name }: { name: string }) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(name);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function startEdit() {
+    setValue(name);
+    setError(null);
+    setEditing(true);
+    setTimeout(() => inputRef.current?.select(), 0);
+  }
+
+  function cancel() {
+    setEditing(false);
+    setError(null);
+  }
+
+  function save() {
+    startTransition(async () => {
+      const result = await updateNameAction(value);
+      if (result.error) {
+        setError(result.error);
+        return;
+      }
+      setEditing(false);
+      setError(null);
+    });
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter") save();
+    if (e.key === "Escape") cancel();
+  }
+
+  if (!editing) {
+    return (
+      <button
+        type="button"
+        onClick={startEdit}
+        className="cursor-pointer text-sm text-gray-600 hover:underline"
+        title="クリックして名前を変更"
+      >
+        {name}
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        disabled={isPending}
+        className="rounded border border-gray-300 px-2 py-0.5 text-sm text-gray-900 focus:border-blue-500 focus:outline-none"
+        style={{ width: `${Math.max(value.length, 4) + 4}ch` }}
+      />
+      <button
+        type="button"
+        onClick={save}
+        disabled={isPending}
+        className="rounded bg-blue-600 px-2 py-0.5 text-xs text-white hover:bg-blue-700 disabled:opacity-50"
+      >
+        保存
+      </button>
+      <button
+        type="button"
+        onClick={cancel}
+        disabled={isPending}
+        className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-600 hover:bg-gray-100 disabled:opacity-50"
+      >
+        キャンセル
+      </button>
+      {error && <span className="text-xs text-red-600">{error}</span>}
+    </div>
+  );
+}

--- a/src/components/ProfileNameEditor.tsx
+++ b/src/components/ProfileNameEditor.tsx
@@ -24,13 +24,18 @@ export function ProfileNameEditor({ name }: { name: string }) {
 
   function save() {
     startTransition(async () => {
-      const result = await updateNameAction(value);
-      if (result.error) {
-        setError(result.error);
-        return;
+      try {
+        const result = await updateNameAction(value);
+        if (result.error) {
+          setError(result.error);
+          return;
+        }
+        setEditing(false);
+        setError(null);
+      } catch {
+        setError(null);
+        alert("通信エラーが発生しました");
       }
-      setEditing(false);
-      setError(null);
     });
   }
 

--- a/src/lib/users.test.ts
+++ b/src/lib/users.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "./errors";
-import { deleteUser, getUsers, updateCurrentUserName, updateUser } from "./users";
+import { deleteUser, getUsers, updateUserName, updateUser } from "./users";
 
 vi.mock("@/lib/prisma", () => ({
   prisma: {
@@ -99,13 +99,13 @@ describe("updateUser", () => {
   });
 });
 
-describe("updateCurrentUserName", () => {
+describe("updateUserName", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("名前を更新して返す", async () => {
     vi.mocked(prisma.user.update).mockResolvedValue({ id: "user-1", name: "新しい名前" } as never);
 
-    const result = await updateCurrentUserName("user-1", "新しい名前");
+    const result = await updateUserName("user-1", "新しい名前");
 
     expect(prisma.user.update).toHaveBeenCalledWith(
       expect.objectContaining({ where: { id: "user-1" }, data: { name: "新しい名前" } }),
@@ -116,7 +116,7 @@ describe("updateCurrentUserName", () => {
   it("前後の空白をトリムして更新する", async () => {
     vi.mocked(prisma.user.update).mockResolvedValue({ id: "user-1", name: "トリム名" } as never);
 
-    await updateCurrentUserName("user-1", "  トリム名  ");
+    await updateUserName("user-1", "  トリム名  ");
 
     expect(prisma.user.update).toHaveBeenCalledWith(
       expect.objectContaining({ data: { name: "トリム名" } }),
@@ -124,11 +124,11 @@ describe("updateCurrentUserName", () => {
   });
 
   it("空文字の場合は BadRequestError をスロー", async () => {
-    await expect(updateCurrentUserName("user-1", "")).rejects.toThrow(BadRequestError);
+    await expect(updateUserName("user-1", "")).rejects.toThrow(BadRequestError);
   });
 
   it("空白のみの場合は BadRequestError をスロー", async () => {
-    await expect(updateCurrentUserName("user-1", "   ")).rejects.toThrow(BadRequestError);
+    await expect(updateUserName("user-1", "   ")).rejects.toThrow(BadRequestError);
   });
 });
 

--- a/src/lib/users.test.ts
+++ b/src/lib/users.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "./errors";
-import { deleteUser, getUsers, updateUser } from "./users";
+import { deleteUser, getUsers, updateCurrentUserName, updateUser } from "./users";
 
 vi.mock("@/lib/prisma", () => ({
   prisma: {
@@ -10,6 +10,7 @@ vi.mock("@/lib/prisma", () => ({
       findUnique: vi.fn(),
       update: vi.fn(),
       delete: vi.fn(),
+      count: vi.fn(),
     },
     evaluationAssignment: { count: vi.fn() },
     evaluation: { count: vi.fn() },
@@ -95,6 +96,39 @@ describe("updateUser", () => {
     const result = await updateUser("user-1", { isActive: false }, "current-user");
 
     expect(result).toMatchObject({ isActive: false });
+  });
+});
+
+describe("updateCurrentUserName", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("名前を更新して返す", async () => {
+    vi.mocked(prisma.user.update).mockResolvedValue({ id: "user-1", name: "新しい名前" } as never);
+
+    const result = await updateCurrentUserName("user-1", "新しい名前");
+
+    expect(prisma.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "user-1" }, data: { name: "新しい名前" } }),
+    );
+    expect(result).toMatchObject({ name: "新しい名前" });
+  });
+
+  it("前後の空白をトリムして更新する", async () => {
+    vi.mocked(prisma.user.update).mockResolvedValue({ id: "user-1", name: "トリム名" } as never);
+
+    await updateCurrentUserName("user-1", "  トリム名  ");
+
+    expect(prisma.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { name: "トリム名" } }),
+    );
+  });
+
+  it("空文字の場合は BadRequestError をスロー", async () => {
+    await expect(updateCurrentUserName("user-1", "")).rejects.toThrow(BadRequestError);
+  });
+
+  it("空白のみの場合は BadRequestError をスロー", async () => {
+    await expect(updateCurrentUserName("user-1", "   ")).rejects.toThrow(BadRequestError);
   });
 });
 

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -47,6 +47,17 @@ export async function updateUser(
   });
 }
 
+export async function updateCurrentUserName(id: string, name: string) {
+  const trimmed = name.trim();
+  if (!trimmed) throw new BadRequestError("名前を入力してください");
+
+  return prisma.user.update({
+    where: { id },
+    data: { name: trimmed },
+    select: { id: true, name: true },
+  });
+}
+
 export async function deleteUser(id: string, currentUserId: string) {
   if (id === currentUserId) throw new ForbiddenError("自分自身は削除できません");
 

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -47,12 +47,12 @@ export async function updateUser(
   });
 }
 
-export async function updateCurrentUserName(id: string, name: string) {
+export async function updateUserName(userId: string, name: string) {
   const trimmed = name.trim();
   if (!trimmed) throw new BadRequestError("名前を入力してください");
 
   return prisma.user.update({
-    where: { id },
+    where: { id: userId },
     data: { name: trimmed },
     select: { id: true, name: true },
   });


### PR DESCRIPTION
## Summary

- ヘッダーの名前表示をクリックするとインライン編集フォームに切り替わり、保存後に即時反映される
- Enter/Escape キーボード操作に対応
- 空文字・空白のみの入力はバリデーションエラー

## Changes

- `src/lib/users.ts` — `updateCurrentUserName` 関数を追加
- `src/lib/users.test.ts` — `updateCurrentUserName` のユニットテスト4件を追加
- `src/app/(dashboard)/actions.ts` — `updateNameAction` Server Action を追加
- `src/components/ProfileNameEditor.tsx` — インライン編集 Client Component を新規作成
- `src/app/(dashboard)/layout.tsx` — ヘッダーの名前表示を `ProfileNameEditor` に差し替え

## Test plan

- [x] `npm run test -- --run src/lib/users.test.ts` — 18件全パス
- [x] 手動動作確認済み（ot-nemoto/eval-hub#68 参照）

🤖 Generated with [Claude Code](https://claude.com/claude-code)