### PR TITLE
[T167] dependabot.yml にグループ設定を追加して更新PRをまとめる

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,17 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-    target-branch: "develop"
+      interval: weekly
+      day: "monday"
+    target-branch: develop
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
 
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
-      interval: "weekly"
-    target-branch: "develop"
+      interval: weekly
+    target-branch: develop


### PR DESCRIPTION
## Summary

- `groups` 設定を追加し、npm 更新PRを production / development の最大2件にまとめる
- `schedule.day: monday` を追加してスケジュールを明示化

## Changes

- `.github/dependabot.yml` — `groups` と `day: monday` を追加

## Test plan

- [ ] 次回 dependabot 実行時に更新PRがグループ化されて発行されることを確認

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)