### PR TITLE
[T170] ナビゲーションラベルを仕様書に合わせて修正

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -52,8 +52,8 @@ flowchart TD
 
     subgraph Header ["Header（全画面共通）"]
         direction LR
-        H_EVAL("自己評価"):::nav
-        H_MEMBERS("社員一覧"):::nav
+        H_EVAL("評価"):::nav
+        H_MEMBERS("メンバー"):::nav
         H_ADMIN_USERS("ユーザー管理 admin"):::nav
         H_ADMIN_YEARS("年度管理 admin"):::nav
         H_ADMIN_TARGETS("マスタ管理 admin"):::nav
@@ -335,7 +335,7 @@ src/app/layout.tsx（RootLayout）
 
 | コンポーネント | 種別 | 用途 | 使用箇所 |
 |--------------|------|------|---------|
-| `NavLinks` | Client Component | ロールに応じたナビゲーションリンク。member は自己評価・社員一覧、admin はさらに管理メニューを表示 | DashboardLayout |
+| `NavLinks` | Client Component | ロールに応じたナビゲーションリンク。member は評価・メンバー、admin はさらに管理メニューを表示 | DashboardLayout |
 | `SignOutButton` | Clerk 提供 | ログアウト処理。`redirectUrl="/login"` を指定 | DashboardLayout |
 | `ui/Button` | Client Component | 共通ボタン（variant: default / outline / secondary / destructive 等） | 全画面 |
 

--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -4,8 +4,8 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 const memberLinks = [
-  { href: "/evaluations", label: "自己評価" },
-  { href: "/members", label: "社員一覧" },
+  { href: "/evaluations", label: "評価" },
+  { href: "/members", label: "メンバー" },
 ];
 
 const adminLinks = [


### PR DESCRIPTION
## Summary
- `NavLinks.tsx` の `memberLinks` ラベルを修正
  - `「自己評価」` → `「評価」`
  - `「社員一覧」` → `「メンバー」`

## 関連 Issue
Close #239

## Test plan
- [ ] MEMBER（tebasaki）でログインし、ナビに「評価」「メンバー」が表示されることを確認
- [ ] ADMIN（bonjiri）でログインし、ナビに「評価」「メンバー」＋管理系メニューが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)