### PR TITLE
[T178/T179/T180] README書き直し・自動PRワークフロー追加・Actions最新化

### DIFF
--- a/.github/workflows/auto-pr-to-master.yml
+++ b/.github/workflows/auto-pr-to-master.yml
@@ -1,0 +1,119 @@
+name: Auto PR develop → master
+
+on:
+  schedule:
+    - cron: '0 21 * * *' # JST AM6:00 (UTC 21:00)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: auto-pr-develop-to-master
+  cancel-in-progress: false
+
+jobs:
+  auto-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check diff between develop and master
+        id: diff
+        run: |
+          git fetch origin
+          COUNT=$(git log origin/master..origin/develop --oneline | wc -l | tr -d ' ')
+          if [ "$COUNT" -gt 0 ]; then
+            echo "has_diff=true" >> "$GITHUB_OUTPUT"
+            echo "差分あり: ${COUNT} コミット"
+          else
+            echo "has_diff=false" >> "$GITHUB_OUTPUT"
+            echo "差分なし。スキップします。"
+          fi
+
+      - name: Determine bump label and build PR body
+        id: content
+        if: steps.diff.outputs.has_diff == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LABEL="bump:patch"
+          ISSUES_SECTION=""
+
+          # コミットメッセージから Issue 番号を抽出
+          ISSUE_NUMBERS=$(git log origin/master..origin/develop --format="%B" \
+            | grep -oE '(Closes|Fixes|closes|fixes) #[0-9]+' \
+            | grep -oE '[0-9]+' \
+            | sort -u)
+
+          for NUM in $ISSUE_NUMBERS; do
+            ISSUE_DATA=$(gh issue view "$NUM" --json title,labels 2>/dev/null) || continue
+            ISSUE_TITLE=$(echo "$ISSUE_DATA" | jq -r '.title')
+            ISSUE_LABELS=$(echo "$ISSUE_DATA" | jq -r '.labels[].name')
+
+            ISSUES_SECTION="${ISSUES_SECTION}- #${NUM} ${ISSUE_TITLE}\n"
+
+            # enhancement ラベルがあれば bump:minor に昇格
+            if echo "$ISSUE_LABELS" | grep -q "^enhancement$"; then
+              LABEL="bump:minor"
+            fi
+          done
+
+          # Dependabot コミットが含まれる場合はログに記録（patch のまま）
+          if git log origin/master..origin/develop --format="%s" | grep -q "^chore(deps"; then
+            echo "Dependabot コミットを検出 → bump:patch"
+          fi
+
+          # PR 本文を生成
+          {
+            echo "## 概要"
+            echo ""
+            echo "develop ブランチの変更を master にマージします。"
+            echo ""
+            if [ -n "$ISSUES_SECTION" ]; then
+              echo "## 含まれる Issue"
+              echo ""
+              printf "%b" "$ISSUES_SECTION"
+            else
+              echo "## 含まれる変更"
+              echo ""
+              git log origin/master..origin/develop --oneline | head -10 | sed 's/^/- /'
+            fi
+            echo ""
+            echo "🤖 このPRは自動生成されました"
+          } > /tmp/pr_body.md
+
+          echo "label=$LABEL" >> "$GITHUB_OUTPUT"
+          echo "判定ラベル: $LABEL"
+
+      - name: Create or update PR
+        if: steps.diff.outputs.has_diff == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LABEL="${{ steps.content.outputs.label }}"
+          EXISTING_PR=$(gh pr list --base master --head develop --state open --json number --jq '.[0].number')
+
+          if [ -z "$EXISTING_PR" ]; then
+            gh pr create \
+              --base master \
+              --head develop \
+              --title "chore: develop → master $(TZ=Asia/Tokyo date +'%Y-%m-%d')" \
+              --body-file /tmp/pr_body.md \
+              --label "$LABEL"
+            echo "✅ PR を新規作成しました（ラベル: $LABEL）"
+          else
+            # 本文を更新
+            gh pr edit "$EXISTING_PR" --body-file /tmp/pr_body.md
+
+            # ラベルを差し替え
+            gh pr edit "$EXISTING_PR" --remove-label "bump:minor" 2>/dev/null || true
+            gh pr edit "$EXISTING_PR" --remove-label "bump:patch" 2>/dev/null || true
+            gh pr edit "$EXISTING_PR" --add-label "$LABEL"
+
+            echo "✅ PR #${EXISTING_PR} を更新しました（ラベル: $LABEL）"
+          fi

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -14,12 +14,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/README.md
+++ b/README.md
@@ -1,133 +1,51 @@
-# EvalHub — エンジニア評価・キャリアプラン管理システム
+# EvalHub
 
-エンジニアの評価とキャリアプランを Excel から Web アプリへ移行するための管理システム。
-自己評価・上長評価の入力、ロール認定状況の可視化、年度ごとのキャリアプランの記録を一元管理する。
+![CI](https://github.com/ot-nemoto/eval-hub/actions/workflows/ci.yml/badge.svg)
+![Version](https://img.shields.io/github/package-json/v/ot-nemoto/eval-hub)
+![Next.js](https://img.shields.io/badge/Next.js-16-black?logo=next.js)
+![TypeScript](https://img.shields.io/badge/TypeScript-6-3178C6?logo=typescript&logoColor=white)
+![Prisma](https://img.shields.io/badge/Prisma-7-2D3748?logo=prisma&logoColor=white)
+![Clerk](https://img.shields.io/badge/Clerk-Auth-6C47FF?logo=clerk&logoColor=white)
+![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-4-06B6D4?logo=tailwindcss&logoColor=white)
 
-## 解決する課題
+エンジニアの自己評価・評価者評価を年度ごとに記録・管理する評価管理 Web アプリ。
 
-- Excel ファイルの属人管理・バージョン管理の煩雑さ
-- 自己評価と上長評価の突合・集計の手間
-- ロール認定状況（qualified / unqualified）の可視化不足
-- 年度ごとのキャリアプランの変遷が追いにくい
+## 機能
 
-## 技術スタック
+- Clerk によるメールアドレス＋パスワード認証（ADMIN / MEMBER ロール）
+- 評価者アサイン管理（年度ごとに評価者と被評価者を紐付け）
+- 自己評価・評価者評価の入力（採点＋理由テキスト）
+- 評価者コメントの追加・編集・削除
+- 年度ロック（評価編集の一括制限）
+- ユーザー管理（有効化・無効化・削除）
 
-| レイヤー | 技術 |
-|---|---|
-| Frontend | Next.js (App Router) + TypeScript |
-| Styling | Tailwind CSS + shadcn/ui |
-| ORM | Prisma |
-| DB | TiDB Cloud Serverless（MySQL 互換） |
-| 認証 | NextAuth.js |
-| デプロイ | Cloudflare Pages + TiDB Cloud Serverless |
-
-## ユーザーロール
-
-| ロール | 権限 |
-|---|---|
-| `member` | 自分のデータのみ閲覧・編集 |
-| `manager` | 担当メンバーの評価・コメント入力 |
-| `admin` | マスタデータの管理・全データ閲覧 |
-
-## 開発環境のセットアップ
-
-### 必要なもの
-
-- Node.js 20 以上
-- TiDB Cloud Serverless アカウント（無料）
-
-### 手順
-
-```bash
-# 依存関係のインストール
-npm install
-
-# 環境変数の設定
-cp .env.example .env.local
-# .env.local を編集して TiDB の接続情報を設定
-
-# DB スキーマの適用
-npx prisma db push
-
-# マスタデータの投入
-npx prisma db seed
-
-# 開発サーバーの起動
-npm run dev
-```
-
-### 環境変数
-
-```bash
-# .env.local
-DATABASE_URL="mysql://<user>:<password>@<host>:4000/<db>?sslaccept=strict"
-NEXTAUTH_SECRET="your-secret"
-NEXTAUTH_URL="http://localhost:3000"
-```
-
-## ディレクトリ構成
-
-```
-/
-├── app/
-│   ├── (auth)/login/          ← ログイン
-│   ├── (dashboard)/
-│   │   ├── members/           ← 社員一覧・プロフィール
-│   │   ├── career/            ← キャリアプラン・年度目標
-│   │   ├── evaluations/       ← 評価入力（自己・上長）
-│   │   ├── roles/             ← ロール認定状況
-│   │   └── admin/             ← マスタ管理（admin 専用）
-│   └── api/v1/                ← RESTful API
-├── components/
-│   ├── ui/                    ← shadcn/ui ベース
-│   ├── evaluation/
-│   ├── career/
-│   └── role/
-├── lib/
-│   ├── prisma.ts              ← TiDB 接続
-│   ├── auth.ts
-│   └── utils.ts
-├── prisma/
-│   ├── schema.prisma
-│   └── seeds/                 ← マスタデータ JSON
-│       ├── evaluation_items.json
-│       ├── roles.json
-│       ├── role_eval_mappings.json
-│       └── allocations.json
-└── docs/                      ← 設計ドキュメント
-```
+詳細は [docs/product.md](docs/product.md) / [docs/requirements.md](docs/requirements.md) を参照。
 
 ## ドキュメント
 
+設計ドキュメントは [`docs/`](docs/) に格納。
+
 | ファイル | 内容 |
-|---|---|
-| [docs/product.md](docs/product.md) | プロダクト概要・目的・機能全体像 |
-| [docs/requirements.md](docs/requirements.md) | 機能要件・非機能要件・ユースケース |
-| [docs/architecture.md](docs/architecture.md) | 技術スタック・設計方針・TiDB 接続設定 |
-| [docs/api.md](docs/api.md) | API エンドポイント仕様 |
-| [docs/schema.md](docs/schema.md) | DB テーブル定義・インデックス |
-| [docs/tasks.md](docs/tasks.md) | 実装タスク・進捗管理 |
-| [docs/seed.md](docs/seed.md) | マスタデータ管理・判定基準の変更方法 |
+|----------|------|
+| [docs/product.md](docs/product.md) | プロダクト定義・目的 |
+| [docs/requirements.md](docs/requirements.md) | 機能要件・非機能要件・画面一覧 |
+| [docs/architecture.md](docs/architecture.md) | 技術スタック・ディレクトリ構成・実装方針 |
+| [docs/api.md](docs/api.md) | 外部 REST API エンドポイント定義 |
+| [docs/actions.md](docs/actions.md) | Server Actions 定義 |
+| [docs/schema.md](docs/schema.md) | DB スキーマ・Prisma モデル定義 |
+| [docs/ui.md](docs/ui.md) | 画面一覧・遷移・UI コンポーネント仕様 |
+| [docs/auth.md](docs/auth.md) | 認証フロー・保護ルート |
+| [docs/development.md](docs/development.md) | ローカルセットアップ・Prisma 操作・デプロイ手順 |
+| [docs/tasks.md](docs/tasks.md) | フェーズ別マイルストーン |
+| [docs/testing.md](docs/testing.md) | 自動テスト方針・カバレッジ規約・実行手順 |
+| [docs/e2e-scenarios.md](docs/e2e-scenarios.md) | E2E テストシナリオ・手動テスト観点 |
 
-## MVP スコープ
+## クイックスタート
 
-> 「社員が自己評価を入力し、上長が評価・コメントを記録し、ロール認定状況を確認できる」
+セットアップ・環境変数の詳細は [docs/development.md](docs/development.md) を参照。
 
-| フェーズ | 内容 | 対象 |
-|---|---|---|
-| Phase 1 | 基盤構築（認証・DB・マスタデータ） | MVP |
-| Phase 2 | 評価入力・ロール認定 | MVP |
-| Phase 3 | キャリアプラン・年度目標 | MVP |
-| Phase 4 | 月次実績・配点管理 | v1.1 以降 |
-| Phase 5 | UI整備・ダッシュボード | v1.1 以降 |
-
-## ロール認定ロジック
-
-評価採点（可/良/優）と各ロールの要求水準を比較して自動判定する。
-判定基準は `prisma/seeds/role_eval_mappings.json` を編集して再シードするだけで変更可能。
-
-```
-必須項目（○）: すべて required_level 以上 → pass
-半必須項目（△）: 過半数が required_level 以上 → pass
-両方満たす → qualified / どちらか未達 → unqualified
+```bash
+npm install
+# 環境変数を設定してから起動（docs/development.md 参照）
+npm run dev   # http://localhost:3000
 ```


### PR DESCRIPTION
## 概要

daily-hub で実施した基盤整備（Issues #163/#165/#168）を eval-hub にも適用。

## 変更内容

- **T178 (#258)**: README.md を現行スタック（Clerk/PostgreSQL/Vercel）に書き直し、バッジ7種を追加
- **T179 (#259)**: `auto-pr-to-master.yml` を追加（毎朝 JST 6:00 に develop → master の PR を自動作成・bump ラベル自動付与）
- **T180 (#260)**: GitHub Actions を v4 → v5 に更新（ci.yml / bump-version.yml / release.yml）

## Closes

Closes #258
Closes #259
Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)