### PR TITLE
[T181] CI トリガーから master を削除し bot PR の action_required を解消

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - develop
-      - master
 
 jobs:
   test:


### PR DESCRIPTION
## 概要

`auto-pr-to-master.yml` が作成する develop → master の PR で CI が `action_required` で止まる問題を修正。

## 変更内容

`ci.yml` のトリガーから `master` を削除。

- **変更前**: develop・master への PR で CI を実行
- **変更後**: develop への PR のみで CI を実行

develop → master の自動 PR は develop 時点で CI 通過済みのため再実行不要。`if: github.actor != 'github-actions[bot]'` をジョブ条件に追加する方法は GitHub がジョブキュー前にワークフランを `action_required` にするため効果なし。

## Closes

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)