### PR TITLE
[T182] auto-pr-to-master を PAT 使用に変更し CI・Bump を自動発火させる

### DIFF
--- a/.github/workflows/auto-pr-to-master.yml
+++ b/.github/workflows/auto-pr-to-master.yml
@@ -39,7 +39,7 @@ jobs:
         id: content
         if: steps.diff.outputs.has_diff == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTO_PR_TOKEN }}
         run: |
           LABEL="bump:patch"
           ISSUES_SECTION=""
@@ -93,7 +93,7 @@ jobs:
       - name: Create or update PR
         if: steps.diff.outputs.has_diff == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTO_PR_TOKEN }}
         run: |
           LABEL="${{ steps.content.outputs.label }}"
           EXISTING_PR=$(gh pr list --base master --head develop --state open --json number --jq '.[0].number')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - develop
+      - master
 
 jobs:
   test:


### PR DESCRIPTION
## 概要

\`auto-pr-to-master.yml\` が \`GITHUB_TOKEN\` を使って PR を作成しているため、CI・bump-version が自動発火しない問題を修正。\`AUTO_PR_TOKEN\`（PAT）に切り替えることで完全自動化する。

あわせて、T181（#263）で GITHUB_TOKEN 制限の回避策として削除した \`ci.yml\` の \`master\` トリガーを復元する。PAT 使用により制限がなくなるため、auto-pr が作成した develop → master の PR でも CI が正常に発火する。

## 変更内容

### auto-pr-to-master.yml
\`GH_TOKEN\` を 2箇所変更：

\`\`\`yaml
# 変更前
GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}

# 変更後
GH_TOKEN: \${{ secrets.AUTO_PR_TOKEN }}
\`\`\`

### ci.yml
T181 で削除した \`master\` トリガーを復元：

\`\`\`yaml
on:
  pull_request:
    branches:
      - develop
      - master  # 復元（PAT 使用により auto-pr PR でも CI が発火するため）
\`\`\`

## 事前作業（完了済み）

- [x] Fine-grained PAT を作成（All repositories、Contents/Issues/Pull requests/Workflows: Read and write）
- [x] \`AUTO_PR_TOKEN\` をリポジトリシークレットに登録

## Closes

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)