### PR TITLE
[T184] bump-version のコミットメッセージに [skip ci] を追加

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -36,5 +36,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json package-lock.json
-          git commit -m "chore: bump version to ${{ steps.bump.outputs.version }}"
+          git commit -m "chore: bump version to ${{ steps.bump.outputs.version }} [skip ci]"
           git push


### PR DESCRIPTION
## 概要

bump-version が `GITHUB_TOKEN` で push した後、CI が `action_required`（0 jobs）になる問題を修正。

## 変更内容

`.github/workflows/bump-version.yml` のコミットメッセージに `[skip ci]` を追加。

```
# 変更前
chore: bump version to 0.16.0

# 変更後
chore: bump version to 0.16.0 [skip ci]
```

GitHub Actions はコミットメッセージに `[skip ci]` が含まれる push の `synchronize` イベントに対して CI をスキップするため、`action_required` が解消される。

## 関連 Issue

Closes #276