### PR TITLE
chore: develop → master 2026-04-24

### DIFF
--- a/.github/workflows/auto-pr-to-master.yml
+++ b/.github/workflows/auto-pr-to-master.yml
@@ -99,13 +99,17 @@ jobs:
           EXISTING_PR=$(gh pr list --base master --head develop --state open --json number --jq '.[0].number')
 
           if [ -z "$EXISTING_PR" ]; then
-            PR_URL=$(gh pr create \
-              --base master \
-              --head develop \
-              --title "chore: develop → master $(TZ=Asia/Tokyo date +'%Y-%m-%d')" \
-              --body-file /tmp/pr_body.md)
-            PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
-            gh pr edit "$PR_NUMBER" --add-label "$LABEL"
+            PR_BODY=$(cat /tmp/pr_body.md)
+            PR_NUMBER=$(gh api repos/${{ github.repository }}/pulls \
+              --method POST \
+              --field title="chore: develop → master $(TZ=Asia/Tokyo date +'%Y-%m-%d')" \
+              --field body="$PR_BODY" \
+              --field head="develop" \
+              --field base="master" \
+              --jq '.number')
+            gh api repos/${{ github.repository }}/issues/$PR_NUMBER/labels \
+              --method POST \
+              --field "labels[]=$LABEL"
             echo "✅ PR を新規作成しました（ラベル: $LABEL）"
           else
             # 本文を更新

--- a/.github/workflows/auto-pr-to-master.yml
+++ b/.github/workflows/auto-pr-to-master.yml
@@ -96,29 +96,37 @@ jobs:
           GH_TOKEN: ${{ secrets.AUTO_PR_TOKEN }}
         run: |
           LABEL="${{ steps.content.outputs.label }}"
-          EXISTING_PR=$(gh pr list --base master --head develop --state open --json number --jq '.[0].number')
+          REPO="${{ github.repository }}"
+          OWNER="${{ github.repository_owner }}"
+          PR_BODY=$(cat /tmp/pr_body.md)
+
+          # 既存の open PR を REST API で確認（GraphQL 不使用）
+          EXISTING_PR=$(gh api "repos/$REPO/pulls?base=master&head=${OWNER}:develop&state=open" --jq '.[0].number // empty')
 
           if [ -z "$EXISTING_PR" ]; then
-            PR_BODY=$(cat /tmp/pr_body.md)
-            PR_NUMBER=$(gh api repos/${{ github.repository }}/pulls \
+            # 新規 PR を REST API で作成
+            PR_NUMBER=$(gh api "repos/$REPO/pulls" \
               --method POST \
               --field title="chore: develop → master $(TZ=Asia/Tokyo date +'%Y-%m-%d')" \
               --field body="$PR_BODY" \
               --field head="develop" \
               --field base="master" \
               --jq '.number')
-            gh api repos/${{ github.repository }}/issues/$PR_NUMBER/labels \
+            # ラベルを REST API で追加
+            gh api "repos/$REPO/issues/$PR_NUMBER/labels" \
               --method POST \
               --field "labels[]=$LABEL"
             echo "✅ PR を新規作成しました（ラベル: $LABEL）"
           else
-            # 本文を更新
-            gh pr edit "$EXISTING_PR" --body-file /tmp/pr_body.md
-
-            # ラベルを差し替え
-            gh pr edit "$EXISTING_PR" --remove-label "bump:minor" 2>/dev/null || true
-            gh pr edit "$EXISTING_PR" --remove-label "bump:patch" 2>/dev/null || true
-            gh pr edit "$EXISTING_PR" --add-label "$LABEL"
-
+            # 本文を REST API で更新
+            gh api "repos/$REPO/pulls/$EXISTING_PR" \
+              --method PATCH \
+              --field body="$PR_BODY"
+            # ラベルを REST API で差し替え
+            gh api "repos/$REPO/issues/$EXISTING_PR/labels/bump%3Aminor" --method DELETE 2>/dev/null || true
+            gh api "repos/$REPO/issues/$EXISTING_PR/labels/bump%3Apatch" --method DELETE 2>/dev/null || true
+            gh api "repos/$REPO/issues/$EXISTING_PR/labels" \
+              --method POST \
+              --field "labels[]=$LABEL"
             echo "✅ PR #${EXISTING_PR} を更新しました（ラベル: $LABEL）"
           fi

--- a/.github/workflows/auto-pr-to-master.yml
+++ b/.github/workflows/auto-pr-to-master.yml
@@ -99,12 +99,13 @@ jobs:
           EXISTING_PR=$(gh pr list --base master --head develop --state open --json number --jq '.[0].number')
 
           if [ -z "$EXISTING_PR" ]; then
-            gh pr create \
+            PR_URL=$(gh pr create \
               --base master \
               --head develop \
               --title "chore: develop → master $(TZ=Asia/Tokyo date +'%Y-%m-%d')" \
-              --body-file /tmp/pr_body.md \
-              --label "$LABEL"
+              --body-file /tmp/pr_body.md)
+            PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+            gh pr edit "$PR_NUMBER" --add-label "$LABEL"
             echo "✅ PR を新規作成しました（ラベル: $LABEL）"
           else
             # 本文を更新

--- a/package-lock.json
+++ b/package-lock.json
@@ -153,6 +153,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -998,6 +999,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1046,6 +1048,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1198,7 +1201,8 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
       "integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.1.1",
@@ -2586,6 +2590,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3814,8 +3819,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3848,6 +3852,7 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -3864,6 +3869,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3874,6 +3880,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4138,7 +4145,7 @@
       }
     },
     "node_modules/ast-types": {
-      "version": "0.16.0",
+      "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
       "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
       "license": "MIT",
@@ -4268,6 +4275,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4990,8 +4998,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "17.4.2",
@@ -5315,6 +5322,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5862,6 +5870,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
       "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6712,7 +6721,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7020,6 +7028,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
       "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.2.4",
         "@swc/helpers": "0.5.15",
@@ -7545,7 +7554,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7561,7 +7569,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7572,7 +7579,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7601,6 +7607,7 @@
       "integrity": "sha512-HlgwRBt1uEFB9LStHL4HLYDvoi4BNu1rYA0hPG0zCAEyK9SaZBqp7E5Rjpc3Qh8Lex/ye/svoHZ0OWoFNhWxuQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "7.7.0",
         "@prisma/dev": "0.24.3",
@@ -7780,6 +7787,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7789,6 +7797,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7801,8 +7810,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
@@ -8733,6 +8741,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -8791,6 +8800,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8931,6 +8941,7 @@
       "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.115.0",
         "lightningcss": "^1.32.0",
@@ -9399,6 +9410,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eval-hub",
-  "version": "0.16.1",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eval-hub",
-      "version": "0.16.1",
+      "version": "0.16.0",
       "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.4.1",
@@ -4138,7 +4138,7 @@
       }
     },
     "node_modules/ast-types": {
-      "version": "0.16.1",
+      "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
       "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
       "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eval-hub",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eval-hub",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eval-hub",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "private": true,
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eval-hub",
-  "version": "0.16.1",
+  "version": "0.16.0",
   "private": true,
   "prisma": {
     "seed": "tsx prisma/seed.ts"


### PR DESCRIPTION
## 概要

develop ブランチの変更を master にマージします。

## 含まれる変更

- 2855e1d chore: バージョンを 0.16.0 に戻す（動作確認後の復元）
- 57aab8c chore: bump version to 0.16.1 [skip ci]
- 0d28348 fix: gh pr コマンドを全て REST API に置き換え（read:org スコープ不要化）
- 8dcef9e fix: gh pr create を REST API に置き換え（read:org スコープ不要化）
- 0774071 fix: gh pr create --label を gh pr edit --add-label に変更（read:org スコープ不要化）

🤖 このPRは自動生成されました