### PR TITLE
fix: [T185] PR description の Closes 参照も bump ラベル判定に含める

### DIFF
--- a/.github/workflows/auto-pr-to-master.yml
+++ b/.github/workflows/auto-pr-to-master.yml
@@ -47,8 +47,21 @@ jobs:
           # コミットメッセージから Issue 番号を抽出
           ISSUE_NUMBERS=$(git log origin/master..origin/develop --format="%B" \
             | grep -oE '(Closes|Fixes|closes|fixes) #[0-9]+' \
+            | grep -oE '[0-9]+' || true)
+
+          # マージコミットの PR description からも Issue 番号を抽出
+          PR_NUMBERS=$(git log origin/master..origin/develop --format="%s" \
+            | grep -oE 'pull request #[0-9]+' \
             | grep -oE '[0-9]+' \
-            | sort -u)
+            | sort -u || true)
+          for PR_NUM in $PR_NUMBERS; do
+            PR_CLOSES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUM}" --jq '.body // ""' 2>/dev/null \
+              | grep -oE '(Closes|Fixes|closes|fixes) #[0-9]+' \
+              | grep -oE '[0-9]+' || true)
+            ISSUE_NUMBERS="${ISSUE_NUMBERS} ${PR_CLOSES}"
+          done
+
+          ISSUE_NUMBERS=$(echo "$ISSUE_NUMBERS" | tr ' ' '\n' | grep -v '^$' | sort -u || true)
 
           for NUM in $ISSUE_NUMBERS; do
             ISSUE_DATA=$(gh issue view "$NUM" --json title,labels 2>/dev/null) || continue


### PR DESCRIPTION
## 概要

`auto-pr-to-master.yml` の bump ラベル判定が PR description の `Closes #N` を拾えなかった問題を修正。

マージコミットのタイトルから PR 番号を抽出し、各 PR の description も検索対象に追加する。

## 関連 Issue

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)