### PR TITLE
feat: T190 デザインを daily-hub 準拠に統一

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="52" height="52" viewBox="0 0 52 52" fill="none" stroke="#18181b" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="26" y1="4" x2="26" y2="8" stroke-width="2"/>
+  <path d="M14 16 L26 8 L38 16 L40 20 L12 20 Z" stroke-width="2.5" fill="none"/>
+  <path d="M10 30 L26 20 L42 30 L44 35 L8 35 Z" stroke-width="2.5" fill="none"/>
+  <line x1="8" y1="35" x2="44" y2="35" stroke-width="2"/>
+  <rect x="18" y="35" width="16" height="12" stroke-width="2.5" fill="none"/>
+  <line x1="8" y1="47" x2="44" y2="47" stroke-width="2.5"/>
+</svg>

--- a/src/app/(dashboard)/admin/fiscal-years/page.tsx
+++ b/src/app/(dashboard)/admin/fiscal-years/page.tsx
@@ -62,7 +62,7 @@ export default async function FiscalYearsPage() {
               </tr>
             ) : (
               fiscalYears.map((fy) => (
-                <tr key={fy.year} className={fy.isCurrent ? "bg-blue-50" : "hover:bg-gray-50"}>
+                <tr key={fy.year} className={fy.isCurrent ? "bg-zinc-50" : "hover:bg-gray-50"}>
                   <td className="px-4 py-3 font-medium text-gray-900">{fy.year}</td>
                   <td className="px-4 py-3 text-gray-700">{fy.name}</td>
                   <td className="px-4 py-3 text-gray-500">
@@ -73,7 +73,7 @@ export default async function FiscalYearsPage() {
                   </td>
                   <td className="px-4 py-3">
                     {fy.isCurrent ? (
-                      <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
+                      <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-700">
                         現在
                       </span>
                     ) : (

--- a/src/app/(dashboard)/admin/users/[id]/evaluation-settings/page.tsx
+++ b/src/app/(dashboard)/admin/users/[id]/evaluation-settings/page.tsx
@@ -32,7 +32,7 @@ export default async function UserEvaluationSettingsPage({
   return (
     <div>
       <div className="mb-6">
-        <Link href="/admin/users" className="text-sm text-blue-600 hover:underline">
+        <Link href="/admin/users" className="text-sm text-zinc-700 hover:underline">
           ← ユーザー管理に戻る
         </Link>
         <h2 className="mt-2 text-xl font-bold text-gray-900">自己評価要否設定</h2>

--- a/src/app/(dashboard)/admin/users/page.tsx
+++ b/src/app/(dashboard)/admin/users/page.tsx
@@ -77,7 +77,7 @@ export default async function AdminUsersPage() {
                   <td className="px-4 py-3">
                     <Link
                       href={`/admin/users/${user.id}/evaluation-settings`}
-                      className="text-blue-600 hover:underline text-xs"
+                      className="text-zinc-700 hover:underline text-xs"
                     >
                       設定 →
                     </Link>

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -30,7 +30,7 @@ export default async function DashboardLayout({ children }: { children: React.Re
   const [years, currentYear] = await Promise.all([getFiscalYears(), getCurrentFiscalYear()]);
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-zinc-50">
       <header className="sticky top-0 z-10 border-b border-zinc-200 bg-white px-6 py-3">
         <div className="mx-auto flex max-w-5xl items-center justify-between">
           <div className="flex items-center gap-6">

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -31,10 +31,20 @@ export default async function DashboardLayout({ children }: { children: React.Re
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <header className="border-b bg-white px-6 py-4">
+      <header className="sticky top-0 z-10 border-b border-zinc-200 bg-white px-6 py-3">
         <div className="mx-auto flex max-w-5xl items-center justify-between">
           <div className="flex items-center gap-6">
-            <h1 className="text-lg font-semibold text-gray-900">{APP_NAME}</h1>
+            <h1 className="flex items-center gap-1.5 text-base font-bold text-zinc-900">
+              <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 52 52" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <line x1="26" y1="4" x2="26" y2="8" strokeWidth="2"/>
+                <path d="M14 16 L26 8 L38 16 L40 20 L12 20 Z" strokeWidth="2.5" fill="none"/>
+                <path d="M10 30 L26 20 L42 30 L44 35 L8 35 Z" strokeWidth="2.5" fill="none"/>
+                <line x1="8" y1="35" x2="44" y2="35" strokeWidth="2"/>
+                <rect x="18" y="35" width="16" height="12" strokeWidth="2.5" fill="none"/>
+                <line x1="8" y1="47" x2="44" y2="47" strokeWidth="2.5"/>
+              </svg>
+              {APP_NAME}
+            </h1>
             <NavLinks role={session.user.role} />
           </div>
           <div className="flex items-center gap-4">

--- a/src/app/(dashboard)/members/page.tsx
+++ b/src/app/(dashboard)/members/page.tsx
@@ -86,7 +86,7 @@ export default async function MembersPage() {
                   <td className="px-4 py-3 font-medium text-gray-900">{member.name}</td>
                   <td className="px-4 py-3 text-gray-500">{member.division ?? "—"}</td>
                   <td className="px-4 py-3 text-right">
-                    <Link href={getLinkHref(member.id)} className="text-blue-600 hover:underline">
+                    <Link href={getLinkHref(member.id)} className="text-zinc-700 hover:underline">
                       {getLinkLabel(member.id)}
                     </Link>
                   </td>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,8 +7,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-mplus1code-base), monospace;
+  --font-mplus1code: var(--font-mplus1code-base), monospace;
+  --font-mono: var(--font-mplus1code-base), monospace;
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,22 +1,24 @@
 import { ClerkProvider } from "@clerk/nextjs";
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { M_PLUS_1_Code } from "next/font/google";
 import { APP_NAME } from "@/lib/constants";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const mPlus1Code = M_PLUS_1_Code({
+  variable: "--font-mplus1code-base",
   subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+  weight: ["400", "500", "700"],
 });
 
 export const metadata: Metadata = {
-  title: APP_NAME,
+  title: {
+    default: APP_NAME,
+    template: `%s | ${APP_NAME}`,
+  },
   description: APP_NAME,
+  icons: {
+    icon: "/favicon.svg",
+  },
 };
 
 export default function RootLayout({
@@ -27,7 +29,7 @@ export default function RootLayout({
   return (
     <ClerkProvider>
       <html lang="ja">
-        <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <body className={`${mPlus1Code.variable} font-mplus1code antialiased`}>
           {children}
         </body>
       </html>

--- a/src/components/ProfileNameEditor.tsx
+++ b/src/components/ProfileNameEditor.tsx
@@ -67,14 +67,14 @@ export function ProfileNameEditor({ name }: { name: string }) {
         onKeyDown={handleKeyDown}
         aria-label="プロフィール名"
         disabled={isPending}
-        className="rounded border border-gray-300 px-2 py-0.5 text-sm text-gray-900 focus:border-blue-500 focus:outline-none"
+        className="rounded border border-gray-300 px-2 py-0.5 text-sm text-gray-900 focus:border-zinc-500 focus:outline-none"
         style={{ width: `${Math.max(value.length, 4) + 4}ch` }}
       />
       <button
         type="button"
         onClick={save}
         disabled={isPending}
-        className="rounded bg-blue-600 px-2 py-0.5 text-xs text-white hover:bg-blue-700 disabled:opacity-50"
+        className="rounded bg-zinc-700 px-2 py-0.5 text-xs text-white hover:bg-zinc-800 disabled:opacity-50"
       >
         保存
       </button>

--- a/src/components/admin/AdminUserFilter.tsx
+++ b/src/components/admin/AdminUserFilter.tsx
@@ -33,7 +33,7 @@ export function AdminUserFilter({ basePath, users, selectedUserId }: Props) {
         id="user-filter"
         value={selectedUserId ?? ""}
         onChange={handleChange}
-        className="rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+        className="rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-zinc-400 focus:outline-none"
       >
         <option value="">全員</option>
         {users.map((u) => (

--- a/src/components/admin/AdminYearSelector.tsx
+++ b/src/components/admin/AdminYearSelector.tsx
@@ -35,7 +35,7 @@ export function AdminYearSelector({ basePath, fiscalYears, selectedYear }: Props
         id="year-selector"
         value={selectedYear ?? ""}
         onChange={handleChange}
-        className="rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+        className="rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-zinc-400 focus:outline-none"
       >
         {fiscalYears.length === 0 && <option value="">年度が登録されていません</option>}
         {fiscalYears.map((fy) => (

--- a/src/components/admin/CategoryActions.tsx
+++ b/src/components/admin/CategoryActions.tsx
@@ -72,7 +72,7 @@ export function CategoryActions({ category, canDelete }: Props) {
         <button
           type="submit"
           disabled={loading}
-          className="rounded border border-blue-400 px-2 py-1 text-xs text-blue-600 hover:bg-blue-50 disabled:opacity-50"
+          className="rounded border border-zinc-400 px-2 py-1 text-xs text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
         >
           保存
         </button>

--- a/src/components/admin/CategoryForm.tsx
+++ b/src/components/admin/CategoryForm.tsx
@@ -37,7 +37,7 @@ export function CategoryForm({ targetId }: Props) {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="rounded border border-blue-300 px-2 py-1 text-xs text-blue-600 hover:bg-blue-50"
+        className="rounded border border-zinc-300 px-2 py-1 text-xs text-zinc-700 hover:bg-zinc-50"
       >
         ＋ 中分類を追加
       </button>
@@ -60,7 +60,7 @@ export function CategoryForm({ targetId }: Props) {
           required
           value={form.no}
           onChange={(e) => setForm((p) => ({ ...p, no: e.target.value }))}
-          className="w-16 rounded border border-gray-300 px-2 py-1 text-xs focus:border-blue-400 focus:outline-none"
+          className="w-16 rounded border border-gray-300 px-2 py-1 text-xs focus:border-zinc-400 focus:outline-none"
           placeholder="1"
         />
       </div>
@@ -77,14 +77,14 @@ export function CategoryForm({ targetId }: Props) {
           required
           value={form.name}
           onChange={(e) => setForm((p) => ({ ...p, name: e.target.value }))}
-          className="rounded border border-gray-300 px-2 py-1 text-xs focus:border-blue-400 focus:outline-none"
+          className="rounded border border-gray-300 px-2 py-1 text-xs focus:border-zinc-400 focus:outline-none"
           placeholder="engagement"
         />
       </div>
       <button
         type="submit"
         disabled={loading}
-        className="rounded bg-blue-600 px-3 py-1 text-xs text-white hover:bg-blue-700 disabled:opacity-50"
+        className="rounded bg-zinc-700 px-3 py-1 text-xs text-white hover:bg-zinc-800 disabled:opacity-50"
       >
         追加
       </button>

--- a/src/components/admin/EvaluationAssignmentForm.tsx
+++ b/src/components/admin/EvaluationAssignmentForm.tsx
@@ -48,7 +48,7 @@ export function EvaluationAssignmentForm({ fiscalYear, users }: Props) {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="rounded border border-blue-400 px-3 py-1.5 text-sm text-blue-600 hover:bg-blue-50"
+        className="rounded border border-zinc-400 px-3 py-1.5 text-sm text-zinc-700 hover:bg-zinc-50"
       >
         ＋ アサインを追加
       </button>
@@ -70,7 +70,7 @@ export function EvaluationAssignmentForm({ fiscalYear, users }: Props) {
             required
             value={evaluateeId}
             onChange={(e) => setEvaluateeId(e.target.value)}
-            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-zinc-400 focus:outline-none"
           >
             <option value="">選択してください</option>
             {users.map((u) => (
@@ -89,7 +89,7 @@ export function EvaluationAssignmentForm({ fiscalYear, users }: Props) {
             required
             value={evaluatorId}
             onChange={(e) => setEvaluatorId(e.target.value)}
-            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-zinc-400 focus:outline-none"
           >
             <option value="">選択してください</option>
             {users.map((u) => (
@@ -104,7 +104,7 @@ export function EvaluationAssignmentForm({ fiscalYear, users }: Props) {
         <button
           type="submit"
           disabled={loading}
-          className="rounded bg-blue-600 px-4 py-1.5 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+          className="rounded bg-zinc-700 px-4 py-1.5 text-sm text-white hover:bg-zinc-800 disabled:opacity-50"
         >
           追加
         </button>

--- a/src/components/admin/EvaluationAssignmentYearSelector.tsx
+++ b/src/components/admin/EvaluationAssignmentYearSelector.tsx
@@ -25,7 +25,7 @@ export function EvaluationAssignmentYearSelector({ fiscalYears, selectedYear }: 
         id="year-selector"
         value={selectedYear ?? ""}
         onChange={handleChange}
-        className="rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+        className="rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-zinc-400 focus:outline-none"
       >
         {fiscalYears.length === 0 && <option value="">年度が登録されていません</option>}
         {fiscalYears.map((fy) => (

--- a/src/components/admin/EvaluationItemActions.tsx
+++ b/src/components/admin/EvaluationItemActions.tsx
@@ -97,7 +97,7 @@ export function EvaluationItemActions({ item, hasEvaluations }: Props) {
           <button
             type="submit"
             disabled={loading}
-            className="rounded border border-blue-400 px-2 py-1 text-xs text-blue-600 hover:bg-blue-50 disabled:opacity-50"
+            className="rounded border border-zinc-400 px-2 py-1 text-xs text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
           >
             保存
           </button>

--- a/src/components/admin/EvaluationItemForm.tsx
+++ b/src/components/admin/EvaluationItemForm.tsx
@@ -66,7 +66,7 @@ export function EvaluationItemForm({ targets, categories }: Props) {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="rounded border border-blue-400 px-3 py-1.5 text-sm text-blue-600 hover:bg-blue-50"
+        className="rounded border border-zinc-400 px-3 py-1.5 text-sm text-zinc-700 hover:bg-zinc-50"
       >
         ＋ 評価項目を追加
       </button>
@@ -87,7 +87,7 @@ export function EvaluationItemForm({ targets, categories }: Props) {
             required
             value={form.targetId}
             onChange={handleChange}
-            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-zinc-400 focus:outline-none"
           >
             <option value="">選択してください</option>
             {targets.map((t) => (
@@ -108,7 +108,7 @@ export function EvaluationItemForm({ targets, categories }: Props) {
             value={form.categoryId}
             onChange={handleChange}
             disabled={!form.targetId}
-            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none disabled:bg-gray-50 disabled:text-gray-400"
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-zinc-400 focus:outline-none disabled:bg-gray-50 disabled:text-gray-400"
           >
             <option value="">選択してください</option>
             {filteredCategories.map((c) => (
@@ -129,7 +129,7 @@ export function EvaluationItemForm({ targets, categories }: Props) {
             required
             value={form.name}
             onChange={handleChange}
-            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-zinc-400 focus:outline-none"
           />
         </div>
         <div className="col-span-2">
@@ -142,7 +142,7 @@ export function EvaluationItemForm({ targets, categories }: Props) {
             value={form.description}
             onChange={handleChange}
             rows={2}
-            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-zinc-400 focus:outline-none"
           />
         </div>
         <div className="col-span-2">
@@ -155,7 +155,7 @@ export function EvaluationItemForm({ targets, categories }: Props) {
             value={form.evalCriteria}
             onChange={handleChange}
             rows={2}
-            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-zinc-400 focus:outline-none"
           />
         </div>
       </div>
@@ -163,7 +163,7 @@ export function EvaluationItemForm({ targets, categories }: Props) {
         <button
           type="submit"
           disabled={loading}
-          className="rounded bg-blue-600 px-4 py-1.5 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+          className="rounded bg-zinc-700 px-4 py-1.5 text-sm text-white hover:bg-zinc-800 disabled:opacity-50"
         >
           追加
         </button>

--- a/src/components/admin/EvaluationSettingToggle.tsx
+++ b/src/components/admin/EvaluationSettingToggle.tsx
@@ -33,7 +33,7 @@ export function EvaluationSettingToggle({ userId, fiscalYear, enabled }: Props) 
       onClick={handleToggle}
       disabled={loading}
       className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors disabled:opacity-50 ${
-        enabled ? "bg-blue-600" : "bg-gray-300"
+        enabled ? "bg-zinc-700" : "bg-gray-300"
       }`}
     >
       <span

--- a/src/components/admin/FiscalYearActions.tsx
+++ b/src/components/admin/FiscalYearActions.tsx
@@ -131,7 +131,7 @@ export function FiscalYearActions({ fiscalYear, isDeletable }: Props) {
         <button
           type="submit"
           disabled={loading}
-          className="rounded border border-blue-400 px-2 py-1 text-xs text-blue-600 hover:bg-blue-50 disabled:opacity-50"
+          className="rounded border border-zinc-400 px-2 py-1 text-xs text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
         >
           保存
         </button>
@@ -154,7 +154,7 @@ export function FiscalYearActions({ fiscalYear, isDeletable }: Props) {
           type="button"
           onClick={handleSetCurrent}
           disabled={loading}
-          className="rounded border border-blue-300 px-2 py-1 text-xs text-blue-600 hover:bg-blue-50 disabled:opacity-50"
+          className="rounded border border-zinc-300 px-2 py-1 text-xs text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
         >
           現在年度に設定
         </button>

--- a/src/components/admin/FiscalYearForm.tsx
+++ b/src/components/admin/FiscalYearForm.tsx
@@ -52,7 +52,7 @@ export function FiscalYearForm() {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="rounded border border-blue-400 px-3 py-1.5 text-sm text-blue-600 hover:bg-blue-50"
+        className="rounded border border-zinc-400 px-3 py-1.5 text-sm text-zinc-700 hover:bg-zinc-50"
       >
         ＋ 年度を追加
       </button>
@@ -74,7 +74,7 @@ export function FiscalYearForm() {
             required
             value={form.year}
             onChange={handleChange}
-            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-zinc-400 focus:outline-none"
             placeholder="2028"
           />
         </div>
@@ -89,7 +89,7 @@ export function FiscalYearForm() {
             required
             value={form.name}
             onChange={handleChange}
-            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-zinc-400 focus:outline-none"
             placeholder="2028年度"
           />
         </div>
@@ -104,7 +104,7 @@ export function FiscalYearForm() {
             required
             value={form.startDate}
             onChange={handleChange}
-            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-zinc-400 focus:outline-none"
           />
         </div>
         <div>
@@ -118,7 +118,7 @@ export function FiscalYearForm() {
             required
             value={form.endDate}
             onChange={handleChange}
-            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-zinc-400 focus:outline-none"
           />
         </div>
       </div>
@@ -126,7 +126,7 @@ export function FiscalYearForm() {
         <button
           type="submit"
           disabled={loading}
-          className="rounded bg-blue-600 px-4 py-1.5 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+          className="rounded bg-zinc-700 px-4 py-1.5 text-sm text-white hover:bg-zinc-800 disabled:opacity-50"
         >
           追加
         </button>

--- a/src/components/admin/RoleSelect.tsx
+++ b/src/components/admin/RoleSelect.tsx
@@ -38,7 +38,7 @@ export function RoleSelect({ userId, currentRole, disabled }: Props) {
       onChange={handleChange}
       disabled={disabled || loading}
       aria-label="ロール"
-      className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 focus:border-blue-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+      className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 focus:border-zinc-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
     >
       <option value="ADMIN">ADMIN</option>
       <option value="MEMBER">MEMBER</option>

--- a/src/components/admin/TargetActions.tsx
+++ b/src/components/admin/TargetActions.tsx
@@ -66,7 +66,7 @@ export function TargetActions({ target, canDelete }: Props) {
         <button
           type="submit"
           disabled={loading}
-          className="rounded border border-blue-400 px-2 py-1 text-xs text-blue-600 hover:bg-blue-50 disabled:opacity-50"
+          className="rounded border border-zinc-400 px-2 py-1 text-xs text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
         >
           保存
         </button>

--- a/src/components/admin/TargetForm.tsx
+++ b/src/components/admin/TargetForm.tsx
@@ -31,7 +31,7 @@ export function TargetForm() {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="rounded border border-blue-300 px-3 py-1.5 text-sm text-blue-600 hover:bg-blue-50"
+        className="rounded border border-zinc-300 px-3 py-1.5 text-sm text-zinc-700 hover:bg-zinc-50"
       >
         ＋ 大分類を追加
       </button>
@@ -51,7 +51,7 @@ export function TargetForm() {
           required
           value={form.no}
           onChange={(e) => setForm((p) => ({ ...p, no: e.target.value }))}
-          className="w-16 rounded border border-gray-300 px-2 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+          className="w-16 rounded border border-gray-300 px-2 py-1.5 text-sm focus:border-zinc-400 focus:outline-none"
           placeholder="1"
         />
       </div>
@@ -65,14 +65,14 @@ export function TargetForm() {
           required
           value={form.name}
           onChange={(e) => setForm((p) => ({ ...p, name: e.target.value }))}
-          className="rounded border border-gray-300 px-2 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+          className="rounded border border-gray-300 px-2 py-1.5 text-sm focus:border-zinc-400 focus:outline-none"
           placeholder="大分類名"
         />
       </div>
       <button
         type="submit"
         disabled={loading}
-        className="rounded bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+        className="rounded bg-zinc-700 px-3 py-1.5 text-sm text-white hover:bg-zinc-800 disabled:opacity-50"
       >
         追加
       </button>

--- a/src/components/evaluation/EvaluationTabs.tsx
+++ b/src/components/evaluation/EvaluationTabs.tsx
@@ -100,7 +100,7 @@ export default function EvaluationTabs({ items, fiscalYear, isLocked = false }: 
             onClick={() => setActiveCategory(cat)}
             className={`whitespace-nowrap px-4 py-2 text-sm font-medium transition-colors ${
               activeCategory === cat
-                ? "border-b-2 border-blue-600 text-blue-600"
+                ? "border-b-2 border-zinc-700 text-zinc-700"
                 : "text-gray-500 hover:text-gray-700"
             }`}
           >
@@ -139,7 +139,7 @@ export default function EvaluationTabs({ items, fiscalYear, isLocked = false }: 
                         onClick={() => setScores((s) => ({ ...s, [item.uid]: score }))}
                         className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
                           scores[item.uid] === score
-                            ? "bg-blue-600 text-white"
+                            ? "bg-zinc-700 text-white"
                             : "border border-gray-300 text-gray-700 hover:bg-gray-50"
                         }`}
                       >
@@ -167,7 +167,7 @@ export default function EvaluationTabs({ items, fiscalYear, isLocked = false }: 
                     </label>
                     <textarea
                       id={`reason-${item.uid}`}
-                      className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                      className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
                       rows={3}
                       value={reasons[item.uid] ?? ""}
                       onChange={(e) => setReasons((r) => ({ ...r, [item.uid]: e.target.value }))}

--- a/src/components/evaluation/ManagerEvaluationTabs.tsx
+++ b/src/components/evaluation/ManagerEvaluationTabs.tsx
@@ -207,7 +207,7 @@ export default function ManagerEvaluationTabs({
             onClick={() => setActiveCategory(cat)}
             className={`whitespace-nowrap px-4 py-2 text-sm font-medium transition-colors ${
               activeCategory === cat
-                ? "border-b-2 border-blue-600 text-blue-600"
+                ? "border-b-2 border-zinc-700 text-zinc-700"
                 : "text-gray-500 hover:text-gray-700"
             }`}
           >
@@ -266,7 +266,7 @@ export default function ManagerEvaluationTabs({
                           onClick={() => setFinalScores((s) => ({ ...s, [item.uid]: score }))}
                           className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
                             finalScores[item.uid] === score
-                              ? "bg-blue-600 text-white"
+                              ? "bg-zinc-700 text-white"
                               : "border border-gray-300 text-gray-700 hover:bg-gray-50"
                           }`}
                         >
@@ -351,7 +351,7 @@ export default function ManagerEvaluationTabs({
                       {isEditing ? (
                         <div className="mt-2 space-y-2">
                           <textarea
-                            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
                             rows={3}
                             value={editReason[cm.id] ?? ""}
                             onChange={(e) =>
@@ -390,10 +390,10 @@ export default function ManagerEvaluationTabs({
 
               {/* コメント追加フォーム（readOnly / isLocked 時は非表示） */}
               {!effectiveReadOnly && adding[item.uid] ? (
-                <div className="space-y-2 rounded-md border border-blue-200 bg-blue-50 p-3">
+                <div className="space-y-2 rounded-md border border-zinc-200 bg-zinc-50 p-3">
                   <p className="text-sm font-medium text-gray-700">コメントを追加</p>
                   <textarea
-                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
                     rows={3}
                     placeholder="コメント・採点理由（任意）"
                     value={newReason[item.uid] ?? ""}


### PR DESCRIPTION
## Summary

- フォントを Geist から M PLUS 1 Code に変更（daily-hub と統一）
- `public/favicon.svg` を二重屋根アイコンで新規作成
- ヘッダーにアイコンを追加（28px、daily-hub と同サイズ感）
- カラーパレットを `blue-*` から `zinc-*` に全面統一
- `metadata` に `title template` と favicon を追加

Closes #320

## Test plan

- [ ] フォントが M PLUS 1 Code に変わっていること
- [ ] ブラウザタブに二重屋根の favicon が表示されること
- [ ] ヘッダーのタイトル横にアイコンが表示されること
- [ ] ボタン・タブ等の色が zinc 系になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)