### PR TITLE
[T195] Biome lint 警告の一括修正

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -27,7 +27,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "correctness": {
         "noUnusedImports": "error",
         "noUnusedVariables": "error"

--- a/src/components/FiscalYearSelector.tsx
+++ b/src/components/FiscalYearSelector.tsx
@@ -17,7 +17,7 @@ export function FiscalYearSelector({ years, currentYear }: Props) {
       value={selectedYear ?? ""}
       onChange={(e) => {
         const year = parseInt(e.target.value, 10);
-        if (!isNaN(year)) {
+        if (!Number.isNaN(year)) {
           setSelectedYear(year);
           setFiscalYearAction(year);
         }

--- a/src/components/ProfileNameEditor.tsx
+++ b/src/components/ProfileNameEditor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useRef, useState, useTransition } from "react";
+import type React from "react";
+import { useRef, useState, useTransition } from "react";
 import { updateNameAction } from "@/app/(dashboard)/actions";
 
 export function ProfileNameEditor({ name }: { name: string }) {

--- a/src/components/admin/EvaluationMatrix.tsx
+++ b/src/components/admin/EvaluationMatrix.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Score } from "@prisma/client";
+import type { Score } from "@prisma/client";
 import { useState } from "react";
 
 const SCORE_LABEL: Record<Score, string> = {

--- a/src/components/admin/MasterList.tsx
+++ b/src/components/admin/MasterList.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import {
   DndContext,
-  DragEndEvent,
+  type DragEndEvent,
   KeyboardSensor,
   PointerSensor,
   closestCenter,

--- a/src/components/evaluation/ManagerEvaluationTabs.tsx
+++ b/src/components/evaluation/ManagerEvaluationTabs.tsx
@@ -253,7 +253,7 @@ export default function ManagerEvaluationTabs({
                 <p className="text-sm font-medium text-gray-700">最終評価スコア</p>
                 {effectiveReadOnly ? (
                   <span className="inline-block rounded-md border bg-white px-3 py-1.5 text-sm font-medium text-gray-700">
-                    {finalScores[item.uid] != null ? SCORE_LABELS[finalScores[item.uid] as Score] : "未設定"}
+                    {(() => { const s = finalScores[item.uid]; return s != null ? SCORE_LABELS[s] : "未設定"; })()}
                   </span>
                 ) : (
                   <>

--- a/src/components/evaluation/ManagerEvaluationTabs.tsx
+++ b/src/components/evaluation/ManagerEvaluationTabs.tsx
@@ -131,7 +131,8 @@ export default function ManagerEvaluationTabs({
       if (result.error) {
         setErrors((e) => ({ ...e, [`add-${uid}`]: result.error ?? "保存に失敗しました" }));
       } else if (result.comment) {
-        setComments((c) => ({ ...c, [uid]: [...(c[uid] ?? []), result.comment!] }));
+        const newComment = result.comment;
+        setComments((c) => ({ ...c, [uid]: [...(c[uid] ?? []), newComment] }));
         setAdding((a) => ({ ...a, [uid]: false }));
         setNewReason((r) => ({ ...r, [uid]: "" }));
       }
@@ -152,9 +153,10 @@ export default function ManagerEvaluationTabs({
       if (result.error) {
         setErrors((e) => ({ ...e, [commentId]: result.error ?? "保存に失敗しました" }));
       } else if (result.comment) {
+        const updated = result.comment;
         setComments((c) => ({
           ...c,
-          [uid]: c[uid].map((cm) => (cm.id === commentId ? result.comment! : cm)),
+          [uid]: c[uid].map((cm) => (cm.id === commentId ? updated : cm)),
         }));
         setEditing((ed) => ({ ...ed, [commentId]: false }));
       }
@@ -251,7 +253,7 @@ export default function ManagerEvaluationTabs({
                 <p className="text-sm font-medium text-gray-700">最終評価スコア</p>
                 {effectiveReadOnly ? (
                   <span className="inline-block rounded-md border bg-white px-3 py-1.5 text-sm font-medium text-gray-700">
-                    {finalScores[item.uid] != null ? SCORE_LABELS[finalScores[item.uid]!] : "未設定"}
+                    {finalScores[item.uid] != null ? SCORE_LABELS[finalScores[item.uid] as Score] : "未設定"}
                   </span>
                 ) : (
                   <>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -18,7 +18,7 @@ export async function getSession(): Promise<Session | null> {
         where: { id: process.env.MOCK_USER_ID },
         select: { id: true, name: true, role: true, isActive: true },
       });
-      if (!user || !user.isActive) return null;
+      if (!user?.isActive) return null;
       return { user: { id: user.id, name: user.name, role: user.role } };
     }
     if (process.env.MOCK_USER_EMAIL) {
@@ -26,7 +26,7 @@ export async function getSession(): Promise<Session | null> {
         where: { email: process.env.MOCK_USER_EMAIL },
         select: { id: true, name: true, role: true, isActive: true },
       });
-      if (!user || !user.isActive) return null;
+      if (!user?.isActive) return null;
       return { user: { id: user.id, name: user.name, role: user.role } };
     }
   }
@@ -76,7 +76,7 @@ export async function getSession(): Promise<Session | null> {
           where: { email },
           select: { id: true, name: true, role: true, isActive: true },
         });
-        if (!user || !user.isActive) return null;
+        if (!user?.isActive) return null;
         return { user: { id: user.id, name: user.name, role: user.role } };
       }
       throw e;
@@ -100,7 +100,7 @@ export async function getSession(): Promise<Session | null> {
       where: { email },
       select: { id: true, name: true, role: true, isActive: true },
     });
-    if (!user || !user.isActive) return null;
+    if (!user?.isActive) return null;
     return { user: { id: user.id, name: user.name, role: user.role } };
   }
 


### PR DESCRIPTION
## Summary
- `biome.json` のスキーマバージョンと deprecated 設定を更新
- `noGlobalIsNan`, `useImportType`, `noNonNullAssertion`, `useOptionalChain` の警告 11 件を修正
- `npm run lint` で警告ゼロ、全 215 テスト合格を確認

## Test plan
- [x] `npm run lint` で警告・エラーが 0 件であること
- [x] `npx vitest run` で全テスト（215件）が合格すること

Closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)