### PR TITLE
[T197] 評価項目API（POST）を全削除→INSERT方式に変更

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -22,7 +22,7 @@ Authorization: Bearer <api_key>
 | メソッド | パス | 説明 |
 |---------|------|------|
 | `GET` | `/api/evaluation-items` | 評価項目一覧の取得 |
-| `POST` | `/api/evaluation-items` | 評価項目の一括登録（upsert） |
+| `POST` | `/api/evaluation-items` | 評価項目の一括登録（全削除→INSERT） |
 
 ---
 
@@ -53,8 +53,8 @@ Authorization: Bearer <api_key>
 
 ## POST /api/evaluation-items
 
-大項目（Target）→ 中項目（Category）→ 評価項目（EvaluationItem）の階層構造で一括 upsert する。
-`no` をキーとして既存データを更新し、存在しない場合は新規作成する。
+大項目（Target）→ 中項目（Category）→ 評価項目（EvaluationItem）の階層構造で一括登録する。
+既存の作業スペースデータ（targets / categories / evaluation_items）を全削除してから INSERT する。バージョン（eval_item_versions）には影響しない。
 
 ### リクエストボディ
 
@@ -83,7 +83,7 @@ Authorization: Bearer <api_key>
 
 | フィールド | 型 | 必須 | 説明 |
 |-----------|---|------|------|
-| `no` | number | ✓ | upsert キー（大項目は全体でユニーク、中項目は大項目内でユニーク、評価項目は中項目内でユニーク） |
+| `no` | number | ✓ | 表示順番号（大項目は全体でユニーク、中項目は大項目内でユニーク、評価項目は中項目内でユニーク） |
 | `name` | string | ✓ | 名称 |
 | `description` | string \| null | — | 説明（評価項目のみ） |
 | `evalCriteria` | string \| null | — | 評価基準（評価項目のみ） |
@@ -92,7 +92,7 @@ Authorization: Bearer <api_key>
 
 ```json
 {
-  "data": { "upserted": 3 },
+  "data": { "created": 3 },
   "meta": {
     "items": [
       { "targetNo": 1, "categoryNo": 1, "itemNo": 1, "name": "評価項目A" }

--- a/src/app/api/evaluation-items/route.test.ts
+++ b/src/app/api/evaluation-items/route.test.ts
@@ -7,14 +7,14 @@ vi.mock("@/lib/apiAuth", () => ({
 
 vi.mock("@/lib/prisma", () => ({
   prisma: {
-    evaluationItem: { findMany: vi.fn(), upsert: vi.fn() },
-    target: { upsert: vi.fn() },
-    category: { upsert: vi.fn() },
+    evaluationItem: { findMany: vi.fn(), create: vi.fn(), deleteMany: vi.fn() },
+    target: { create: vi.fn(), deleteMany: vi.fn() },
+    category: { create: vi.fn(), deleteMany: vi.fn() },
     $transaction: vi.fn((cb: (tx: unknown) => Promise<unknown>) =>
       cb({
-        target: { upsert: vi.mocked(prisma.target.upsert) },
-        category: { upsert: vi.mocked(prisma.category.upsert) },
-        evaluationItem: { upsert: vi.mocked(prisma.evaluationItem.upsert) },
+        target: { create: vi.mocked(prisma.target.create), deleteMany: vi.mocked(prisma.target.deleteMany) },
+        category: { create: vi.mocked(prisma.category.create), deleteMany: vi.mocked(prisma.category.deleteMany) },
+        evaluationItem: { create: vi.mocked(prisma.evaluationItem.create), deleteMany: vi.mocked(prisma.evaluationItem.deleteMany) },
       }),
     ),
   },
@@ -92,24 +92,28 @@ describe("POST /api/evaluation-items", () => {
     },
   ];
 
-  it("有効なリクエストで upsert を実行して結果を返す", async () => {
+  it("有効なリクエストで全削除→INSERT を実行して結果を返す", async () => {
     vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
-    vi.mocked(prisma.target.upsert).mockResolvedValue({ id: 1, no: 1, name: "社員" } as never);
-    vi.mocked(prisma.category.upsert).mockResolvedValue({
+    vi.mocked(prisma.target.create).mockResolvedValue({ id: 1, no: 1, name: "社員" } as never);
+    vi.mocked(prisma.category.create).mockResolvedValue({
       id: 1,
+      targetId: 1,
       no: 1,
       name: "エンゲージメント",
     } as never);
-    vi.mocked(prisma.evaluationItem.upsert).mockResolvedValue(mockItem as never);
+    vi.mocked(prisma.evaluationItem.create).mockResolvedValue(mockItem as never);
 
     const res = await POST(makeRequest(validBody));
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body.data.upserted).toBe(1);
-    expect(prisma.target.upsert).toHaveBeenCalledTimes(1);
-    expect(prisma.category.upsert).toHaveBeenCalledTimes(1);
-    expect(prisma.evaluationItem.upsert).toHaveBeenCalledTimes(1);
+    expect(body.data.created).toBe(1);
+    expect(prisma.evaluationItem.deleteMany).toHaveBeenCalledTimes(1);
+    expect(prisma.category.deleteMany).toHaveBeenCalledTimes(1);
+    expect(prisma.target.deleteMany).toHaveBeenCalledTimes(1);
+    expect(prisma.target.create).toHaveBeenCalledTimes(1);
+    expect(prisma.category.create).toHaveBeenCalledTimes(1);
+    expect(prisma.evaluationItem.create).toHaveBeenCalledTimes(1);
   });
 
   it("API キーが無効な場合は 401 を返す", async () => {

--- a/src/app/api/evaluation-items/route.test.ts
+++ b/src/app/api/evaluation-items/route.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { Prisma } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/apiAuth", () => ({
@@ -12,9 +13,18 @@ vi.mock("@/lib/prisma", () => ({
     category: { create: vi.fn(), deleteMany: vi.fn() },
     $transaction: vi.fn((cb: (tx: unknown) => Promise<unknown>) =>
       cb({
-        target: { create: vi.mocked(prisma.target.create), deleteMany: vi.mocked(prisma.target.deleteMany) },
-        category: { create: vi.mocked(prisma.category.create), deleteMany: vi.mocked(prisma.category.deleteMany) },
-        evaluationItem: { create: vi.mocked(prisma.evaluationItem.create), deleteMany: vi.mocked(prisma.evaluationItem.deleteMany) },
+        target: {
+          create: vi.mocked(prisma.target.create),
+          deleteMany: vi.mocked(prisma.target.deleteMany),
+        },
+        category: {
+          create: vi.mocked(prisma.category.create),
+          deleteMany: vi.mocked(prisma.category.deleteMany),
+        },
+        evaluationItem: {
+          create: vi.mocked(prisma.evaluationItem.create),
+          deleteMany: vi.mocked(prisma.evaluationItem.deleteMany),
+        },
       }),
     ),
   },
@@ -180,5 +190,21 @@ describe("POST /api/evaluation-items", () => {
 
     const res = await POST(req);
     expect(res.status).toBe(400);
+  });
+
+  it("no 重複（P2002）は 400 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(prisma.target.create).mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError("Unique constraint", {
+        code: "P2002",
+        clientVersion: "5.0.0",
+      }),
+    );
+
+    const res = await POST(makeRequest(validBody));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error.message).toBe("no が重複しています");
   });
 });

--- a/src/app/api/evaluation-items/route.ts
+++ b/src/app/api/evaluation-items/route.ts
@@ -109,29 +109,25 @@ export async function POST(req: NextRequest) {
     created = await prisma.$transaction(async (tx) => {
       const result: typeof created = [];
 
+      // 全削除（FK順: 評価項目→中分類→大分類）
+      await tx.evaluationItem.deleteMany({});
+      await tx.category.deleteMany({});
+      await tx.target.deleteMany({});
+
+      // 再挿入（大分類→中分類→評価項目）
       for (const targetInput of body as TargetInput[]) {
-        const target = await tx.target.upsert({
-          where: { no: targetInput.no },
-          update: { name: targetInput.name },
-          create: { no: targetInput.no, name: targetInput.name },
+        const target = await tx.target.create({
+          data: { no: targetInput.no, name: targetInput.name },
         });
 
         for (const categoryInput of targetInput.categories) {
-          const category = await tx.category.upsert({
-            where: { targetId_no: { targetId: target.id, no: categoryInput.no } },
-            update: { name: categoryInput.name },
-            create: { targetId: target.id, no: categoryInput.no, name: categoryInput.name },
+          const category = await tx.category.create({
+            data: { targetId: target.id, no: categoryInput.no, name: categoryInput.name },
           });
 
           for (const itemInput of categoryInput.items) {
-            await tx.evaluationItem.upsert({
-              where: { categoryId_no: { categoryId: category.id, no: itemInput.no } },
-              update: {
-                name: itemInput.name,
-                description: itemInput.description ?? null,
-                evalCriteria: itemInput.evalCriteria ?? null,
-              },
-              create: {
+            await tx.evaluationItem.create({
+              data: {
                 targetId: target.id,
                 categoryId: category.id,
                 no: itemInput.no,
@@ -156,5 +152,5 @@ export async function POST(req: NextRequest) {
     return errorResponse("INTERNAL_SERVER_ERROR", "サーバーエラーが発生しました", 500);
   }
 
-  return successResponse({ upserted: created.length }, { items: created }, 200);
+  return successResponse({ created: created.length }, { items: created }, 200);
 }

--- a/src/app/api/evaluation-items/route.ts
+++ b/src/app/api/evaluation-items/route.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import type { NextRequest } from "next/server";
 import { errorResponse, successResponse } from "@/lib/api-response";
 import { getAuthenticatedUser } from "@/lib/apiAuth";
@@ -148,7 +149,10 @@ export async function POST(req: NextRequest) {
 
       return result;
     });
-  } catch {
+  } catch (e) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
+      return errorResponse("BAD_REQUEST", "no が重複しています", 400);
+    }
     return errorResponse("INTERNAL_SERVER_ERROR", "サーバーエラーが発生しました", 500);
   }
 


### PR DESCRIPTION
## Summary
- 評価項目インポートAPI（POST /api/evaluation-items）を upsert から全削除→INSERT に変更
- バージョン復元機能と同じパターンに統一し、APIに含まれない古い項目が残る問題を解消
- レスポンスキーを `upserted` → `created` に変更

## Test plan
- [x] ユニットテスト更新・全253テストパス
- [x] docs/api.md の記述更新

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)