### PR TITLE
[T198] 年度未設定時のリダイレクトループを修正

### DIFF
--- a/src/app/(dashboard)/evaluations/page.tsx
+++ b/src/app/(dashboard)/evaluations/page.tsx
@@ -10,7 +10,18 @@ export default async function EvaluationsPage() {
   if (!session) redirect("/login");
   const userId = session.user.id;
   const fiscalYear = await getCurrentFiscalYear();
-  if (!fiscalYear) redirect("/login");
+  if (!fiscalYear) {
+    return (
+      <div>
+        <div className="mb-6">
+          <h2 className="text-xl font-bold text-gray-900">自己評価</h2>
+        </div>
+        <div className="rounded-lg border bg-white p-8 text-center text-gray-500">
+          年度が設定されていません。管理者にお問い合わせください。
+        </div>
+      </div>
+    );
+  }
 
   const [fiscalYearRecord, evaluations, setting] = await Promise.all([
     prisma.fiscalYear.findUnique({

--- a/src/app/(dashboard)/members/[id]/evaluations/page.tsx
+++ b/src/app/(dashboard)/members/[id]/evaluations/page.tsx
@@ -15,7 +15,18 @@ export default async function MemberEvaluationsPage({ params }: Props) {
   const evaluatorId = session.user.id;
   const isAdmin = session.user.role === "ADMIN";
   const fiscalYear = await getCurrentFiscalYear();
-  if (!fiscalYear) notFound();
+  if (!fiscalYear) {
+    return (
+      <div>
+        <div className="mb-6">
+          <h2 className="text-xl font-bold text-gray-900">評価</h2>
+        </div>
+        <div className="rounded-lg border bg-white p-8 text-center text-gray-500">
+          年度が設定されていません。管理者にお問い合わせください。
+        </div>
+      </div>
+    );
+  }
 
   // 対象ユーザーが当該年度の被評価者として存在するか確認
   const isEvaluatee = await prisma.evaluationAssignment.findFirst({

--- a/src/app/(dashboard)/members/page.tsx
+++ b/src/app/(dashboard)/members/page.tsx
@@ -11,7 +11,18 @@ export default async function MembersPage() {
   const userId = session.user.id;
   const isAdmin = session.user.role === "ADMIN";
   const fiscalYear = await getCurrentFiscalYear();
-  if (!fiscalYear) redirect("/evaluations");
+  if (!fiscalYear) {
+    return (
+      <div>
+        <div className="mb-6">
+          <h2 className="text-xl font-bold text-gray-900">社員一覧</h2>
+        </div>
+        <div className="rounded-lg border bg-white p-8 text-center text-gray-500">
+          年度が設定されていません。管理者にお問い合わせください。
+        </div>
+      </div>
+    );
+  }
 
   type Member = { id: string; name: string; division: string | null };
 


### PR DESCRIPTION
## Summary
- 年度データが未設定の場合に `/login` や `/evaluations` へリダイレクトしてループする問題を修正
- リダイレクトの代わりに「年度が設定されていません」のメッセージをページ内に表示
- 対象: `evaluations/page.tsx`、`members/page.tsx`、`members/[id]/evaluations/page.tsx`

## Test plan
- [x] 年度未設定状態で `/evaluations` にアクセス → メッセージ表示、ループしない
- [x] 年度未設定状態で `/members` にアクセス → メッセージ表示、ループしない
- [x] 年度未設定状態で `/members/{id}/evaluations` にアクセス → メッセージ表示
- [x] 年度設定済み状態で各ページが正常表示されること
- [x] 未ログイン状態で `/login` にリダイレクトされること

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)