### PR TITLE
[T199] 評価項目APIのバッチINSERTとタイムアウト延長

### DIFF
--- a/src/app/api/evaluation-items/route.test.ts
+++ b/src/app/api/evaluation-items/route.test.ts
@@ -8,7 +8,7 @@ vi.mock("@/lib/apiAuth", () => ({
 
 vi.mock("@/lib/prisma", () => ({
   prisma: {
-    evaluationItem: { findMany: vi.fn(), create: vi.fn(), deleteMany: vi.fn() },
+    evaluationItem: { findMany: vi.fn(), createMany: vi.fn(), deleteMany: vi.fn() },
     target: { create: vi.fn(), deleteMany: vi.fn() },
     category: { create: vi.fn(), deleteMany: vi.fn() },
     $transaction: vi.fn((cb: (tx: unknown) => Promise<unknown>) =>
@@ -22,7 +22,7 @@ vi.mock("@/lib/prisma", () => ({
           deleteMany: vi.mocked(prisma.category.deleteMany),
         },
         evaluationItem: {
-          create: vi.mocked(prisma.evaluationItem.create),
+          createMany: vi.mocked(prisma.evaluationItem.createMany),
           deleteMany: vi.mocked(prisma.evaluationItem.deleteMany),
         },
       }),
@@ -111,7 +111,7 @@ describe("POST /api/evaluation-items", () => {
       no: 1,
       name: "エンゲージメント",
     } as never);
-    vi.mocked(prisma.evaluationItem.create).mockResolvedValue(mockItem as never);
+    vi.mocked(prisma.evaluationItem.createMany).mockResolvedValue({ count: 1 } as never);
 
     const res = await POST(makeRequest(validBody));
     const body = await res.json();
@@ -123,7 +123,8 @@ describe("POST /api/evaluation-items", () => {
     expect(prisma.target.deleteMany).toHaveBeenCalledTimes(1);
     expect(prisma.target.create).toHaveBeenCalledTimes(1);
     expect(prisma.category.create).toHaveBeenCalledTimes(1);
-    expect(prisma.evaluationItem.create).toHaveBeenCalledTimes(1);
+    expect(prisma.evaluationItem.createMany).toHaveBeenCalledTimes(1);
+    expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), { timeout: 30000 });
   });
 
   it("API キーが無効な場合は 401 を返す", async () => {

--- a/src/app/api/evaluation-items/route.ts
+++ b/src/app/api/evaluation-items/route.ts
@@ -107,48 +107,51 @@ export async function POST(req: NextRequest) {
   let created: { targetNo: number; categoryNo: number; itemNo: number; name: string }[] = [];
 
   try {
-    created = await prisma.$transaction(async (tx) => {
-      const result: typeof created = [];
+    created = await prisma.$transaction(
+      async (tx) => {
+        const result: typeof created = [];
 
-      // 全削除（FK順: 評価項目→中分類→大分類）
-      await tx.evaluationItem.deleteMany({});
-      await tx.category.deleteMany({});
-      await tx.target.deleteMany({});
+        // 全削除（FK順: 評価項目→中分類→大分類）
+        await tx.evaluationItem.deleteMany({});
+        await tx.category.deleteMany({});
+        await tx.target.deleteMany({});
 
-      // 再挿入（大分類→中分類→評価項目）
-      for (const targetInput of body as TargetInput[]) {
-        const target = await tx.target.create({
-          data: { no: targetInput.no, name: targetInput.name },
-        });
-
-        for (const categoryInput of targetInput.categories) {
-          const category = await tx.category.create({
-            data: { targetId: target.id, no: categoryInput.no, name: categoryInput.name },
+        // 再挿入（大分類→中分類→評価項目）
+        for (const targetInput of body as TargetInput[]) {
+          const target = await tx.target.create({
+            data: { no: targetInput.no, name: targetInput.name },
           });
 
-          for (const itemInput of categoryInput.items) {
-            await tx.evaluationItem.create({
-              data: {
-                targetId: target.id,
-                categoryId: category.id,
-                no: itemInput.no,
-                name: itemInput.name,
-                description: itemInput.description ?? null,
-                evalCriteria: itemInput.evalCriteria ?? null,
-              },
+          for (const categoryInput of targetInput.categories) {
+            const category = await tx.category.create({
+              data: { targetId: target.id, no: categoryInput.no, name: categoryInput.name },
             });
-            result.push({
-              targetNo: target.no,
-              categoryNo: category.no,
-              itemNo: itemInput.no,
+
+            const itemsData = categoryInput.items.map((itemInput) => ({
+              targetId: target.id,
+              categoryId: category.id,
+              no: itemInput.no,
               name: itemInput.name,
-            });
+              description: itemInput.description ?? null,
+              evalCriteria: itemInput.evalCriteria ?? null,
+            }));
+            await tx.evaluationItem.createMany({ data: itemsData });
+
+            for (const itemInput of categoryInput.items) {
+              result.push({
+                targetNo: target.no,
+                categoryNo: category.no,
+                itemNo: itemInput.no,
+                name: itemInput.name,
+              });
+            }
           }
         }
-      }
 
-      return result;
-    });
+        return result;
+      },
+      { timeout: 30000 },
+    );
   } catch (e) {
     if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
       return errorResponse("BAD_REQUEST", "no が重複しています", 400);


### PR DESCRIPTION
## Summary
- `evaluationItem` の逐次 `create()` を `createMany()` に変更し、DB 往復回数を削減
- `$transaction` に `timeout: 30000`（30秒）を指定し、大量データでのタイムアウトを回避
- 複数カテゴリ・17件以上の評価項目で 500 エラーになる問題を解消

## Test plan
- [x] ユニットテスト更新・全254テストパス
- [x] `createMany` の呼び出しとタイムアウトオプションのアサーション追加

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)