### PR TITLE
[T205] アプリアイコンの viewBox を 0 0 24 24 に統一し、ヘッダーアイコンをコンポーネント化

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,8 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="52" height="52" viewBox="0 0 52 52" fill="none" stroke="#18181b" stroke-linecap="round" stroke-linejoin="round">
-  <line x1="26" y1="4" x2="26" y2="8" stroke-width="2"/>
-  <path d="M14 16 L26 8 L38 16 L40 20 L12 20 Z" stroke-width="2.5" fill="none"/>
-  <path d="M10 30 L26 20 L42 30 L44 35 L8 35 Z" stroke-width="2.5" fill="none"/>
-  <line x1="8" y1="35" x2="44" y2="35" stroke-width="2"/>
-  <rect x="18" y="35" width="16" height="12" stroke-width="2.5" fill="none"/>
-  <line x1="8" y1="47" x2="44" y2="47" stroke-width="2.5"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#18181b" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="12" y1="2" x2="12" y2="3.5" stroke-width="1"/>
+  <path d="M6.5 7.5 L12 3.5 L17.5 7.5 L18.5 9.5 L5.5 9.5 Z" stroke-width="1.2" fill="none"/>
+  <path d="M4.5 14 L12 9.5 L19.5 14 L20.5 16 L3.5 16 Z" stroke-width="1.2" fill="none"/>
+  <line x1="3.5" y1="16" x2="20.5" y2="16" stroke-width="1"/>
+  <rect x="8.5" y="16" width="7" height="5.5" stroke-width="1.2" fill="none"/>
+  <line x1="3.5" y1="21.5" x2="20.5" y2="21.5" stroke-width="1.2"/>
 </svg>

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { FiscalYearSelector } from "@/components/FiscalYearSelector";
+import { AppIcon } from "@/components/icons/AppIcon";
 import { LogoutButton } from "@/components/LogoutButton";
 import { NavLinks } from "@/components/NavLinks";
 import { SettingsModalTrigger } from "@/components/SettingsModalTrigger";
@@ -42,24 +43,7 @@ export default async function DashboardLayout({ children }: { children: React.Re
         <div className="mx-auto flex max-w-5xl items-center justify-between">
           <div className="flex items-center gap-6">
             <h1 className="flex items-center gap-1.5 text-base font-bold text-zinc-900">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="28"
-                height="28"
-                viewBox="0 0 52 52"
-                fill="none"
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden="true"
-              >
-                <line x1="26" y1="4" x2="26" y2="8" strokeWidth="2" />
-                <path d="M14 16 L26 8 L38 16 L40 20 L12 20 Z" strokeWidth="2.5" fill="none" />
-                <path d="M10 30 L26 20 L42 30 L44 35 L8 35 Z" strokeWidth="2.5" fill="none" />
-                <line x1="8" y1="35" x2="44" y2="35" strokeWidth="2" />
-                <rect x="18" y="35" width="16" height="12" strokeWidth="2.5" fill="none" />
-                <line x1="8" y1="47" x2="44" y2="47" strokeWidth="2.5" />
-              </svg>
+              <AppIcon width={28} height={28} />
               {APP_NAME}
             </h1>
             <NavLinks role={session.user.role} />

--- a/src/components/icons/AppIcon.tsx
+++ b/src/components/icons/AppIcon.tsx
@@ -1,0 +1,23 @@
+export function AppIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      <line x1="12" y1="2" x2="12" y2="3.5" strokeWidth="1" />
+      <path d="M6.5 7.5 L12 3.5 L17.5 7.5 L18.5 9.5 L5.5 9.5 Z" strokeWidth="1.2" fill="none" />
+      <path d="M4.5 14 L12 9.5 L19.5 14 L20.5 16 L3.5 16 Z" strokeWidth="1.2" fill="none" />
+      <line x1="3.5" y1="16" x2="20.5" y2="16" strokeWidth="1" />
+      <rect x="8.5" y="16" width="7" height="5.5" strokeWidth="1.2" fill="none" />
+      <line x1="3.5" y1="21.5" x2="20.5" y2="21.5" strokeWidth="1.2" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- `public/favicon.svg` の viewBox を `0 0 52 52` → `0 0 24 24` に変更し座標を再計算
- `src/components/icons/AppIcon.tsx` を新規作成し、SVG をコンポーネント化
- `src/app/(dashboard)/layout.tsx` のインライン SVG を `AppIcon` コンポーネントに置き換え

## Test plan
- [x] ヘッダーアイコンが正しく表示される
- [x] ブラウザタブの favicon が正しく表示される
- [x] 各ページで共通ヘッダーアイコンが表示される

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)