### PR TITLE
fix: seed の NODE_ENV=production 分岐を削除し Clerk ガードを統一

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -9,20 +9,15 @@ dotenv.config({ path: ".env" });
 const adapter = new PrismaNeon({ connectionString: process.env.DATABASE_URL });
 const prisma = new PrismaClient({ adapter });
 
-const clerkClient =
-  process.env.NODE_ENV !== "production" && process.env.CLERK_SECRET_KEY
-    ? createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY })
-    : null;
+const clerkClient = process.env.CLERK_SECRET_KEY
+  ? createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY })
+  : null;
 
 // ─── Clerk ヘルパー ────────────────────────────────────────────────────────────
 
 async function syncClerkUser(email: string): Promise<string | null> {
   if (!clerkClient) {
-    if (process.env.NODE_ENV === "production") {
-      console.warn("  本番環境のため Clerk ユーザー作成をスキップします");
-    } else {
-      console.warn("  CLERK_SECRET_KEY が未設定のため Clerk ユーザー作成をスキップします");
-    }
+    console.warn("  CLERK_SECRET_KEY が未設定のため Clerk ユーザー作成をスキップします");
     return null;
   }
   const existing = await clerkClient.users.getUserList({ emailAddress: [email] });


### PR DESCRIPTION
Closes #373

seed は開発/テスト用（手動実行のみ・vercel-build/CI からは呼ばれない）。production/preview で自動実行されず、`main()` は DB を全削除・再投入するため `NODE_ENV==="production"` 分岐は Clerk 操作だけを止める中途半端な死んだ防御コードだった。

- `NODE_ENV==="production"` 分岐を削除、判定を `CLERK_SECRET_KEY` の有無のみに統一
- dual warning を1本化

挙動：キーがあれば作成／なければ graceful スキップ。3リポ統一の一環（daily も graceful / link は fail-fast）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)