### PR TITLE
[T208/T209] ラベル fix リネーム・バージョン番号ハードコード除去

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ![CI](https://github.com/ot-nemoto/eval-hub/actions/workflows/ci.yml/badge.svg)
 ![Version](https://img.shields.io/github/package-json/v/ot-nemoto/eval-hub)
-![Next.js](https://img.shields.io/badge/Next.js-16-black?logo=next.js)
-![TypeScript](https://img.shields.io/badge/TypeScript-6-3178C6?logo=typescript&logoColor=white)
-![Prisma](https://img.shields.io/badge/Prisma-7-2D3748?logo=prisma&logoColor=white)
-![Clerk](https://img.shields.io/badge/Clerk-Auth-6C47FF?logo=clerk&logoColor=white)
-![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-4-06B6D4?logo=tailwindcss&logoColor=white)
+![Next.js](https://img.shields.io/badge/Next.js-black?logo=next.js)
+![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white)
+![Prisma](https://img.shields.io/badge/Prisma-2D3748?logo=prisma&logoColor=white)
+![Clerk](https://img.shields.io/badge/Clerk-6C47FF?logo=clerk&logoColor=white)
+![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-06B6D4?logo=tailwindcss&logoColor=white)
 
 エンジニアの自己評価・評価者評価を年度ごとに記録・管理する評価管理 Web アプリ。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,16 +4,16 @@
 
 | レイヤー | 技術 | 選定理由 |
 |----------|------|----------|
-| フレームワーク | Next.js 16 (App Router) | SSR/CSR の柔軟な使い分け、TypeScript 標準対応 |
+| フレームワーク | Next.js (App Router) | SSR/CSR の柔軟な使い分け、TypeScript 標準対応 |
 | 言語 | TypeScript (strict) | 型安全、補完が効く |
-| スタイリング | Tailwind CSS v4 + shadcn/ui | 高速な UI 構築、デザイン統一 |
+| スタイリング | Tailwind CSS + shadcn/ui | 高速な UI 構築、デザイン統一 |
 | Lint / Format | Biome | ESLint + Prettier を 1 ツールで代替、高速 |
-| ORM | Prisma 7 | 型安全な DB アクセス、マイグレーション管理 |
+| ORM | Prisma | 型安全な DB アクセス、マイグレーション管理 |
 | DB | PostgreSQL (Neon) | サーバーレス PostgreSQL、Edge 対応、無料枠で運用可能 |
-| 認証 | Clerk (@clerk/nextjs v7, @clerk/backend v3) | ホスト型 UI・セッション管理・ロール制御が容易 |
+| 認証 | Clerk (@clerk/nextjs, @clerk/backend) | ホスト型 UI・セッション管理・ロール制御が容易 |
 | ホスティング | Vercel (Hobby) | Next.js の開発元、無料枠・無期限、デプロイが最も簡単 |
 | ユニットテスト | Vitest | 高速、Vite 互換 |
-| 開発サーバー | Turbopack | Next.js 16 デフォルト、HMR が高速 |
+| 開発サーバー | Turbopack | Next.js デフォルト、HMR が高速 |
 | パッケージ管理 | npm | devcontainer のデフォルト環境に合わせる |
 
 ## 非機能要件


### PR DESCRIPTION
## Summary
- GitHub ラベル `bug` → `fix` にリネーム（common-rules の Issue 作成ルールに準拠）
- `docs/architecture.md` の技術スタックテーブルからバージョン番号を除去（source of truth 原則）
- `README.md` のバッジからバージョン番号を除去

## Test plan
- [x] `gh label list` で `fix` ラベルの存在を確認
- [x] `docs/architecture.md` にバージョン番号のハードコードがないことを確認
- [x] `README.md` のバッジにバージョン番号がないことを確認

Closes #375
Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)