### PR TITLE
[T210] Dependabot の TypeScript 7（ネイティブ版）更新を抑止

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
         dependency-type: production
       development-dependencies:
         dependency-type: development
+    ignore:
+      # TypeScript 7 はネイティブ版（Go 実装）で Next.js 16 の build と非互換。
+      # Next.js がネイティブ版に対応するまでメジャー更新を保留する。
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: devcontainers
     directory: /


### PR DESCRIPTION
## 概要

Dependabot による `typescript` の **メジャー更新（`^6` → `^7`）を抑止**する。

TypeScript 7.0 系はネイティブ版（Go 実装 / tsgo）で、従来型 `typescript` パッケージ構造を前提とする **Next.js 16.2.10 の `next build`（TypeScript チェック）と非互換**。

Closes #378

## 変更

`.github/dependabot.yml` の npm ブロックに `ignore` を追加：
- `typescript` の `version-update:semver-major` を無視
- 6 系のマイナー/パッチ更新は引き続き受け入れる
- Next.js がネイティブ版に対応したら ignore を外す

## 備考

link-hub #295 / daily-hub #332 と同一対応の横展開（予防的）。eval-hub では現時点で該当 Dependabot PR は未発生だが、同条件のため次回 weekly 更新前に設定を入れておく。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
