### PR TITLE
[T212] targets / categories の REST API（CRUD + reorder）

### DIFF
--- a/src/app/api/categories/[id]/route.test.ts
+++ b/src/app/api/categories/[id]/route.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/categories", () => ({ updateCategory: vi.fn(), deleteCategory: vi.fn() }));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { deleteCategory, updateCategory } from "@/lib/categories";
+import { ConflictError, NotFoundError } from "@/lib/errors";
+import { DELETE, PATCH } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+const category = { id: 1, targetId: 1, name: "エンゲージメント", no: 2, index: 1 };
+
+function makeRequest(method: string, body?: unknown) {
+  return new Request("http://localhost/api/categories/1", {
+    method,
+    headers: { "Content-Type": "application/json", authorization: "Bearer key" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  }) as import("next/server").NextRequest;
+}
+
+const ctx = (id = "1") => ({ params: Promise.resolve({ id }) });
+
+describe("PATCH /api/categories/[id]", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("更新して 200 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(updateCategory).mockResolvedValue(category);
+
+    const res = await PATCH(makeRequest("PATCH", { name: "エンゲージメント", no: 2 }), ctx());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual(category);
+    expect(updateCategory).toHaveBeenCalledWith(1, { name: "エンゲージメント", no: 2 });
+  });
+
+  it("未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(updateCategory).mockRejectedValue(new NotFoundError("中分類が見つかりません"));
+    expect((await PATCH(makeRequest("PATCH", { name: "x" }), ctx())).status).toBe(404);
+  });
+
+  it("no 重複は 409", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(updateCategory).mockRejectedValue(
+      new ConflictError("同じ targetId と no の中分類がすでに存在します"),
+    );
+    expect((await PATCH(makeRequest("PATCH", { no: 3 }), ctx())).status).toBe(409);
+  });
+
+  it("id 不正は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await PATCH(makeRequest("PATCH", { name: "x" }), ctx("abc"))).status).toBe(400);
+    expect(updateCategory).not.toHaveBeenCalled();
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await PATCH(makeRequest("PATCH", { name: "x" }), ctx())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await PATCH(makeRequest("PATCH", { name: "x" }), ctx())).status).toBe(403);
+  });
+});
+
+describe("DELETE /api/categories/[id]", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("削除して 204 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(deleteCategory).mockResolvedValue(undefined);
+
+    const res = await DELETE(makeRequest("DELETE"), ctx());
+    expect(res.status).toBe(204);
+    expect(deleteCategory).toHaveBeenCalledWith(1);
+  });
+
+  it("紐づく評価項目あり（ConflictError）は 409", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(deleteCategory).mockRejectedValue(
+      new ConflictError("紐づく評価項目が存在するため削除できません"),
+    );
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(409);
+  });
+
+  it("未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(deleteCategory).mockRejectedValue(new NotFoundError("中分類が見つかりません"));
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(404);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(403);
+  });
+});

--- a/src/app/api/categories/[id]/route.test.ts
+++ b/src/app/api/categories/[id]/route.test.ts
@@ -57,6 +57,12 @@ describe("PATCH /api/categories/[id]", () => {
     expect(updateCategory).not.toHaveBeenCalled();
   });
 
+  it("空 body（name・no とも欠落）は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await PATCH(makeRequest("PATCH", {}), ctx())).status).toBe(400);
+    expect(updateCategory).not.toHaveBeenCalled();
+  });
+
   it("キー無効は 401 / MEMBER は 403", async () => {
     vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
     expect((await PATCH(makeRequest("PATCH", { name: "x" }), ctx())).status).toBe(401);

--- a/src/app/api/categories/[id]/route.ts
+++ b/src/app/api/categories/[id]/route.ts
@@ -1,0 +1,56 @@
+import { type NextRequest, NextResponse } from "next/server";
+import {
+  jsonError,
+  jsonErrorFromException,
+  serializeCategory,
+  unauthorized,
+} from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { deleteCategory, updateCategory } from "@/lib/categories";
+import { firstZodError } from "@/lib/schemas/_zod-error";
+import { categoryUpdateBodySchema } from "@/lib/schemas/category";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+function parseId(id: string): number | null {
+  const n = Number(id);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+export async function PATCH(req: NextRequest, { params }: RouteContext) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const { id } = await params;
+  const categoryId = parseId(id);
+  if (categoryId === null) return jsonError("id は正の整数で指定してください", 400);
+
+  const body = await req.json().catch(() => null);
+  const parsed = categoryUpdateBodySchema.safeParse(body);
+  if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
+
+  try {
+    const category = await updateCategory(categoryId, parsed.data);
+    return NextResponse.json(serializeCategory(category));
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: RouteContext) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const { id } = await params;
+  const categoryId = parseId(id);
+  if (categoryId === null) return jsonError("id は正の整数で指定してください", 400);
+
+  try {
+    await deleteCategory(categoryId);
+    return new NextResponse(null, { status: 204 });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/app/api/categories/reorder/route.test.ts
+++ b/src/app/api/categories/reorder/route.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/categories", () => ({ reorderCategories: vi.fn() }));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { reorderCategories } from "@/lib/categories";
+import { NotFoundError } from "@/lib/errors";
+import { POST } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+
+function makeRequest(body?: unknown) {
+  return new Request("http://localhost/api/categories/reorder", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", authorization: "Bearer key" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  }) as import("next/server").NextRequest;
+}
+
+const validBody = {
+  orders: [
+    { id: 1, index: 2 },
+    { id: 2, index: 1 },
+  ],
+};
+
+describe("POST /api/categories/reorder", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("並び替えて 200 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(reorderCategories).mockResolvedValue(undefined);
+
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+    expect(reorderCategories).toHaveBeenCalledWith(validBody.orders);
+  });
+
+  it("orders 欠落は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makeRequest({}))).status).toBe(400);
+    expect(reorderCategories).not.toHaveBeenCalled();
+  });
+
+  it("対象未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(reorderCategories).mockRejectedValue(
+      new NotFoundError("並び替え対象の中分類が見つかりません"),
+    );
+    expect((await POST(makeRequest(validBody))).status).toBe(404);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await POST(makeRequest(validBody))).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await POST(makeRequest(validBody))).status).toBe(403);
+  });
+});

--- a/src/app/api/categories/reorder/route.test.ts
+++ b/src/app/api/categories/reorder/route.test.ts
@@ -35,7 +35,7 @@ describe("POST /api/categories/reorder", () => {
     vi.mocked(reorderCategories).mockResolvedValue(undefined);
 
     const res = await POST(makeRequest(validBody));
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(204);
     expect(reorderCategories).toHaveBeenCalledWith(validBody.orders);
   });
 

--- a/src/app/api/categories/reorder/route.ts
+++ b/src/app/api/categories/reorder/route.ts
@@ -16,7 +16,7 @@ export async function POST(req: NextRequest) {
 
   try {
     await reorderCategories(parsed.data.orders);
-    return new NextResponse(null, { status: 200 });
+    return new NextResponse(null, { status: 204 });
   } catch (e) {
     return jsonErrorFromException(e);
   }

--- a/src/app/api/categories/reorder/route.ts
+++ b/src/app/api/categories/reorder/route.ts
@@ -1,0 +1,23 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { jsonError, jsonErrorFromException, unauthorized } from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { reorderCategories } from "@/lib/categories";
+import { firstZodError } from "@/lib/schemas/_zod-error";
+import { reorderBodySchema } from "@/lib/schemas/common";
+
+export async function POST(req: NextRequest) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const body = await req.json().catch(() => null);
+  const parsed = reorderBodySchema.safeParse(body);
+  if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
+
+  try {
+    await reorderCategories(parsed.data.orders);
+    return new NextResponse(null, { status: 200 });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/app/api/categories/route.test.ts
+++ b/src/app/api/categories/route.test.ts
@@ -83,6 +83,12 @@ describe("POST /api/categories", () => {
     expect(createCategory).not.toHaveBeenCalled();
   });
 
+  it("name 空文字は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makePost({ targetId: 1, name: "  " }))).status).toBe(400);
+    expect(createCategory).not.toHaveBeenCalled();
+  });
+
   it("大分類が未存在は 404", async () => {
     vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
     vi.mocked(createCategory).mockRejectedValue(new NotFoundError("大分類が見つかりません"));

--- a/src/app/api/categories/route.test.ts
+++ b/src/app/api/categories/route.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/categories", () => ({ getCategories: vi.fn(), createCategory: vi.fn() }));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { createCategory, getCategories } from "@/lib/categories";
+import { ConflictError, NotFoundError } from "@/lib/errors";
+import { GET, POST } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+const category = { id: 1, targetId: 1, name: "エンゲージメント", no: 1, index: 1 };
+
+function makeGet(query = "") {
+  return new Request(`http://localhost/api/categories${query}`, {
+    method: "GET",
+    headers: { authorization: "Bearer key" },
+  }) as import("next/server").NextRequest;
+}
+function makePost(body: unknown) {
+  return new Request("http://localhost/api/categories", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", authorization: "Bearer key" },
+    body: JSON.stringify(body),
+  }) as import("next/server").NextRequest;
+}
+
+describe("GET /api/categories", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("ADMIN は一覧を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(getCategories).mockResolvedValue([category]);
+
+    const res = await GET(makeGet());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ categories: [category] });
+    expect(getCategories).toHaveBeenCalledWith(undefined);
+  });
+
+  it("targetId で絞り込む", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(getCategories).mockResolvedValue([category]);
+
+    await GET(makeGet("?targetId=1"));
+    expect(getCategories).toHaveBeenCalledWith(1);
+  });
+
+  it("targetId 不正は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await GET(makeGet("?targetId=abc"))).status).toBe(400);
+    expect(getCategories).not.toHaveBeenCalled();
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await GET(makeGet())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await GET(makeGet())).status).toBe(403);
+  });
+});
+
+describe("POST /api/categories", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("作成して 201 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(createCategory).mockResolvedValue(category);
+
+    const res = await POST(makePost({ targetId: 1, name: "エンゲージメント" }));
+    const body = await res.json();
+    expect(res.status).toBe(201);
+    expect(body).toEqual(category);
+    expect(createCategory).toHaveBeenCalledWith({ targetId: 1, name: "エンゲージメント" });
+  });
+
+  it("targetId 欠落は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makePost({ name: "x" }))).status).toBe(400);
+    expect(createCategory).not.toHaveBeenCalled();
+  });
+
+  it("大分類が未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(createCategory).mockRejectedValue(new NotFoundError("大分類が見つかりません"));
+    expect((await POST(makePost({ targetId: 99, name: "x" }))).status).toBe(404);
+  });
+
+  it("no 重複は 409", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(createCategory).mockRejectedValue(
+      new ConflictError("同じ targetId と no の中分類がすでに存在します"),
+    );
+    expect((await POST(makePost({ targetId: 1, name: "x" }))).status).toBe(409);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await POST(makePost({ targetId: 1, name: "x" }))).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await POST(makePost({ targetId: 1, name: "x" }))).status).toBe(403);
+  });
+});

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,0 +1,50 @@
+import { type NextRequest, NextResponse } from "next/server";
+import {
+  jsonError,
+  jsonErrorFromException,
+  serializeCategory,
+  unauthorized,
+} from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { createCategory, getCategories } from "@/lib/categories";
+import { firstZodError } from "@/lib/schemas/_zod-error";
+import { categoryCreateBodySchema } from "@/lib/schemas/category";
+
+export async function GET(req: NextRequest) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const targetIdParam = new URL(req.url).searchParams.get("targetId");
+  let targetId: number | undefined;
+  if (targetIdParam !== null) {
+    const n = Number(targetIdParam);
+    if (!Number.isInteger(n) || n < 1)
+      return jsonError("targetId は 1 以上の整数で指定してください", 400);
+    targetId = n;
+  }
+
+  try {
+    const categories = await getCategories(targetId);
+    return NextResponse.json({ categories: categories.map(serializeCategory) });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const body = await req.json().catch(() => null);
+  const parsed = categoryCreateBodySchema.safeParse(body);
+  if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
+
+  try {
+    const category = await createCategory(parsed.data);
+    return NextResponse.json(serializeCategory(category), { status: 201 });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/app/api/targets/[id]/route.test.ts
+++ b/src/app/api/targets/[id]/route.test.ts
@@ -57,6 +57,18 @@ describe("PATCH /api/targets/[id]", () => {
     expect(updateTarget).not.toHaveBeenCalled();
   });
 
+  it("no が 0 以下は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await PATCH(makeRequest("PATCH", { no: -1 }), ctx())).status).toBe(400);
+    expect(updateTarget).not.toHaveBeenCalled();
+  });
+
+  it("空 body（name・no とも欠落）は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await PATCH(makeRequest("PATCH", {}), ctx())).status).toBe(400);
+    expect(updateTarget).not.toHaveBeenCalled();
+  });
+
   it("キー無効は 401 / MEMBER は 403", async () => {
     vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
     expect((await PATCH(makeRequest("PATCH", { name: "x" }), ctx())).status).toBe(401);

--- a/src/app/api/targets/[id]/route.test.ts
+++ b/src/app/api/targets/[id]/route.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/targets", () => ({ updateTarget: vi.fn(), deleteTarget: vi.fn() }));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { ConflictError, NotFoundError } from "@/lib/errors";
+import { deleteTarget, updateTarget } from "@/lib/targets";
+import { DELETE, PATCH } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+const target = { id: 1, name: "社員", no: 2, index: 1 };
+
+function makeRequest(method: string, body?: unknown) {
+  return new Request("http://localhost/api/targets/1", {
+    method,
+    headers: { "Content-Type": "application/json", authorization: "Bearer key" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  }) as import("next/server").NextRequest;
+}
+
+const ctx = (id = "1") => ({ params: Promise.resolve({ id }) });
+
+describe("PATCH /api/targets/[id]", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("更新して 200 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(updateTarget).mockResolvedValue(target);
+
+    const res = await PATCH(makeRequest("PATCH", { name: "社員", no: 2 }), ctx());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual(target);
+    expect(updateTarget).toHaveBeenCalledWith(1, { name: "社員", no: 2 });
+  });
+
+  it("未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(updateTarget).mockRejectedValue(new NotFoundError("大分類が見つかりません"));
+    expect((await PATCH(makeRequest("PATCH", { name: "x" }), ctx())).status).toBe(404);
+  });
+
+  it("no 重複は 409", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(updateTarget).mockRejectedValue(
+      new ConflictError("同じ no の大分類がすでに存在します"),
+    );
+    expect((await PATCH(makeRequest("PATCH", { no: 3 }), ctx())).status).toBe(409);
+  });
+
+  it("id 不正は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await PATCH(makeRequest("PATCH", { name: "x" }), ctx("abc"))).status).toBe(400);
+    expect(updateTarget).not.toHaveBeenCalled();
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await PATCH(makeRequest("PATCH", { name: "x" }), ctx())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await PATCH(makeRequest("PATCH", { name: "x" }), ctx())).status).toBe(403);
+  });
+});
+
+describe("DELETE /api/targets/[id]", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("削除して 204 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(deleteTarget).mockResolvedValue(undefined);
+
+    const res = await DELETE(makeRequest("DELETE"), ctx());
+    expect(res.status).toBe(204);
+    expect(deleteTarget).toHaveBeenCalledWith(1);
+  });
+
+  it("紐づく中分類あり（ConflictError）は 409", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(deleteTarget).mockRejectedValue(
+      new ConflictError("紐づく中分類が存在するため削除できません"),
+    );
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(409);
+  });
+
+  it("未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(deleteTarget).mockRejectedValue(new NotFoundError("大分類が見つかりません"));
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(404);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(403);
+  });
+});

--- a/src/app/api/targets/[id]/route.ts
+++ b/src/app/api/targets/[id]/route.ts
@@ -1,0 +1,56 @@
+import { type NextRequest, NextResponse } from "next/server";
+import {
+  jsonError,
+  jsonErrorFromException,
+  serializeTarget,
+  unauthorized,
+} from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { firstZodError } from "@/lib/schemas/_zod-error";
+import { targetUpdateBodySchema } from "@/lib/schemas/target";
+import { deleteTarget, updateTarget } from "@/lib/targets";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+function parseId(id: string): number | null {
+  const n = Number(id);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+export async function PATCH(req: NextRequest, { params }: RouteContext) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const { id } = await params;
+  const targetId = parseId(id);
+  if (targetId === null) return jsonError("id は正の整数で指定してください", 400);
+
+  const body = await req.json().catch(() => null);
+  const parsed = targetUpdateBodySchema.safeParse(body);
+  if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
+
+  try {
+    const target = await updateTarget(targetId, parsed.data);
+    return NextResponse.json(serializeTarget(target));
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: RouteContext) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const { id } = await params;
+  const targetId = parseId(id);
+  if (targetId === null) return jsonError("id は正の整数で指定してください", 400);
+
+  try {
+    await deleteTarget(targetId);
+    return new NextResponse(null, { status: 204 });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/app/api/targets/reorder/route.test.ts
+++ b/src/app/api/targets/reorder/route.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/targets", () => ({ reorderTargets: vi.fn() }));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { NotFoundError } from "@/lib/errors";
+import { reorderTargets } from "@/lib/targets";
+import { POST } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+
+function makeRequest(body?: unknown) {
+  return new Request("http://localhost/api/targets/reorder", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", authorization: "Bearer key" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  }) as import("next/server").NextRequest;
+}
+
+const validBody = {
+  orders: [
+    { id: 1, index: 2 },
+    { id: 2, index: 1 },
+  ],
+};
+
+describe("POST /api/targets/reorder", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("並び替えて 200 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(reorderTargets).mockResolvedValue(undefined);
+
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+    expect(reorderTargets).toHaveBeenCalledWith(validBody.orders);
+  });
+
+  it("orders 欠落は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makeRequest({}))).status).toBe(400);
+    expect(reorderTargets).not.toHaveBeenCalled();
+  });
+
+  it("空配列は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makeRequest({ orders: [] }))).status).toBe(400);
+  });
+
+  it("対象未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(reorderTargets).mockRejectedValue(
+      new NotFoundError("並び替え対象の大分類が見つかりません"),
+    );
+    expect((await POST(makeRequest(validBody))).status).toBe(404);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await POST(makeRequest(validBody))).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await POST(makeRequest(validBody))).status).toBe(403);
+  });
+});

--- a/src/app/api/targets/reorder/route.test.ts
+++ b/src/app/api/targets/reorder/route.test.ts
@@ -35,7 +35,7 @@ describe("POST /api/targets/reorder", () => {
     vi.mocked(reorderTargets).mockResolvedValue(undefined);
 
     const res = await POST(makeRequest(validBody));
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(204);
     expect(reorderTargets).toHaveBeenCalledWith(validBody.orders);
   });
 

--- a/src/app/api/targets/reorder/route.ts
+++ b/src/app/api/targets/reorder/route.ts
@@ -16,7 +16,7 @@ export async function POST(req: NextRequest) {
 
   try {
     await reorderTargets(parsed.data.orders);
-    return new NextResponse(null, { status: 200 });
+    return new NextResponse(null, { status: 204 });
   } catch (e) {
     return jsonErrorFromException(e);
   }

--- a/src/app/api/targets/reorder/route.ts
+++ b/src/app/api/targets/reorder/route.ts
@@ -1,0 +1,23 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { jsonError, jsonErrorFromException, unauthorized } from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { firstZodError } from "@/lib/schemas/_zod-error";
+import { reorderBodySchema } from "@/lib/schemas/common";
+import { reorderTargets } from "@/lib/targets";
+
+export async function POST(req: NextRequest) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const body = await req.json().catch(() => null);
+  const parsed = reorderBodySchema.safeParse(body);
+  if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
+
+  try {
+    await reorderTargets(parsed.data.orders);
+    return new NextResponse(null, { status: 200 });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/app/api/targets/route.test.ts
+++ b/src/app/api/targets/route.test.ts
@@ -66,6 +66,13 @@ describe("POST /api/targets", () => {
     expect(createTarget).not.toHaveBeenCalled();
   });
 
+  it("name 空文字・空白のみは 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makeRequest({ name: "" }))).status).toBe(400);
+    expect((await POST(makeRequest({ name: "   " }))).status).toBe(400);
+    expect(createTarget).not.toHaveBeenCalled();
+  });
+
   it("no 重複（ConflictError）は 409", async () => {
     vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
     vi.mocked(createTarget).mockRejectedValue(

--- a/src/app/api/targets/route.test.ts
+++ b/src/app/api/targets/route.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/targets", () => ({ getTargets: vi.fn(), createTarget: vi.fn() }));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { ConflictError } from "@/lib/errors";
+import { createTarget, getTargets } from "@/lib/targets";
+import { GET, POST } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+const target = { id: 1, name: "社員", no: 1, index: 1 };
+
+function makeRequest(body?: unknown) {
+  return new Request("http://localhost/api/targets", {
+    method: body !== undefined ? "POST" : "GET",
+    headers: { "Content-Type": "application/json", authorization: "Bearer key" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  }) as import("next/server").NextRequest;
+}
+
+describe("GET /api/targets", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("ADMIN は一覧を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(getTargets).mockResolvedValue([target]);
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ targets: [target] });
+  });
+
+  it("キー無効は 401", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await GET(makeRequest())).status).toBe(401);
+  });
+
+  it("MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await GET(makeRequest())).status).toBe(403);
+  });
+});
+
+describe("POST /api/targets", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("作成して 201 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(createTarget).mockResolvedValue(target);
+
+    const res = await POST(makeRequest({ name: "社員" }));
+    const body = await res.json();
+    expect(res.status).toBe(201);
+    expect(body).toEqual(target);
+    expect(createTarget).toHaveBeenCalledWith({ name: "社員" });
+  });
+
+  it("name 欠落は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    expect(createTarget).not.toHaveBeenCalled();
+  });
+
+  it("no 重複（ConflictError）は 409", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(createTarget).mockRejectedValue(
+      new ConflictError("同じ no の大分類がすでに存在します"),
+    );
+
+    const res = await POST(makeRequest({ name: "社員" }));
+    const body = await res.json();
+    expect(res.status).toBe(409);
+    expect(body.error).toBe("同じ no の大分類がすでに存在します");
+  });
+
+  it("キー無効は 401", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await POST(makeRequest({ name: "社員" }))).status).toBe(401);
+  });
+
+  it("MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await POST(makeRequest({ name: "社員" }))).status).toBe(403);
+  });
+});

--- a/src/app/api/targets/route.ts
+++ b/src/app/api/targets/route.ts
@@ -1,0 +1,41 @@
+import { type NextRequest, NextResponse } from "next/server";
+import {
+  jsonError,
+  jsonErrorFromException,
+  serializeTarget,
+  unauthorized,
+} from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { firstZodError } from "@/lib/schemas/_zod-error";
+import { targetCreateBodySchema } from "@/lib/schemas/target";
+import { createTarget, getTargets } from "@/lib/targets";
+
+export async function GET(req: NextRequest) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  try {
+    const targets = await getTargets();
+    return NextResponse.json({ targets: targets.map(serializeTarget) });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const body = await req.json().catch(() => null);
+  const parsed = targetCreateBodySchema.safeParse(body);
+  if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
+
+  try {
+    const target = await createTarget(parsed.data);
+    return NextResponse.json(serializeTarget(target), { status: 201 });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -56,3 +56,23 @@ export function serializeEvaluationItem(item: SerializableEvaluationItem) {
     category: { id: item.category.id, no: item.category.no, name: item.category.name },
   };
 }
+
+type SerializableTarget = { id: number; name: string; no: number; index: number };
+
+/** 大分類を外部 API レスポンス形式に整形する。 */
+export function serializeTarget(t: SerializableTarget) {
+  return { id: t.id, name: t.name, no: t.no, index: t.index };
+}
+
+type SerializableCategory = {
+  id: number;
+  targetId: number;
+  name: string;
+  no: number;
+  index: number;
+};
+
+/** 中分類を外部 API レスポンス形式に整形する。 */
+export function serializeCategory(c: SerializableCategory) {
+  return { id: c.id, targetId: c.targetId, name: c.name, no: c.no, index: c.index };
+}

--- a/src/lib/openapi/document.test.ts
+++ b/src/lib/openapi/document.test.ts
@@ -4,7 +4,15 @@ import { buildOpenApiDocument } from "./document";
 
 const doc = buildOpenApiDocument({ version: "9.9.9" });
 
-const EXPECTED_PATHS = ["/api/evaluation-items"];
+const EXPECTED_PATHS = [
+  "/api/evaluation-items",
+  "/api/targets",
+  "/api/targets/reorder",
+  "/api/targets/{id}",
+  "/api/categories",
+  "/api/categories/reorder",
+  "/api/categories/{id}",
+];
 
 const HTTP_METHODS = ["get", "post", "patch", "put", "delete"];
 
@@ -51,7 +59,7 @@ describe("buildOpenApiDocument", () => {
       (n, item) => n + Object.keys(item).filter((k) => HTTP_METHODS.includes(k)).length,
       0,
     );
-    expect(opCount).toBe(2);
+    expect(opCount).toBe(12);
   });
 
   it("各オペレーションに summary と responses がある", () => {
@@ -72,10 +80,19 @@ describe("buildOpenApiDocument", () => {
     expect(Object.keys(doc.components.schemas)).toEqual(
       expect.arrayContaining([
         "Error",
+        "ReorderBody",
         "EvaluationItem",
         "EvaluationItemList",
         "EvaluationItemsImport",
         "EvaluationItemsImportResult",
+        "Target",
+        "TargetList",
+        "TargetCreate",
+        "TargetUpdate",
+        "Category",
+        "CategoryList",
+        "CategoryCreate",
+        "CategoryUpdate",
       ]),
     );
   });

--- a/src/lib/openapi/document.ts
+++ b/src/lib/openapi/document.ts
@@ -218,7 +218,7 @@ export function buildOpenApiDocument(options: { version?: string; serverUrl?: st
           tags: ["targets"],
           requestBody: jsonBody("ReorderBody"),
           responses: {
-            200: { description: "並び替え成功（ボディなし）" },
+            204: { description: "並び替え成功（ボディなし）" },
             400: errorResponse("バリデーションエラー"),
             401: errorResponse("認証エラー"),
             403: errorResponse("ADMIN 権限が必要"),
@@ -295,7 +295,7 @@ export function buildOpenApiDocument(options: { version?: string; serverUrl?: st
           tags: ["categories"],
           requestBody: jsonBody("ReorderBody"),
           responses: {
-            200: { description: "並び替え成功（ボディなし）" },
+            204: { description: "並び替え成功（ボディなし）" },
             400: errorResponse("バリデーションエラー"),
             401: errorResponse("認証エラー"),
             403: errorResponse("ADMIN 権限が必要"),

--- a/src/lib/openapi/document.ts
+++ b/src/lib/openapi/document.ts
@@ -1,11 +1,23 @@
 import { z } from "zod";
-import { errorResponseSchema } from "@/lib/schemas/common";
+import {
+  categoryCreateBodySchema,
+  categoryListResponseSchema,
+  categoryResponseSchema,
+  categoryUpdateBodySchema,
+} from "@/lib/schemas/category";
+import { errorResponseSchema, reorderBodySchema } from "@/lib/schemas/common";
 import {
   evaluationItemListResponseSchema,
   evaluationItemResponseSchema,
   evaluationItemsImportBodySchema,
   evaluationItemsImportResponseSchema,
 } from "@/lib/schemas/evaluation-item";
+import {
+  targetCreateBodySchema,
+  targetListResponseSchema,
+  targetResponseSchema,
+  targetUpdateBodySchema,
+} from "@/lib/schemas/target";
 
 /**
  * `info.description`（Markdown）に流し込む API 全体のナラティブ。
@@ -99,6 +111,15 @@ const jsonBody = (name: string) => ({
   content: { "application/json": { schema: ref(name) } },
 });
 
+/** 整数 ID の path パラメータ定義。 */
+const idParam = {
+  name: "id",
+  in: "path",
+  required: true,
+  schema: { type: "integer" },
+  description: "対象リソースの ID",
+};
+
 /** OpenAPI 3.1 ドキュメントを組み立てる。`serverUrl`（アクセス元オリジン）があれば servers 先頭に置く。 */
 export function buildOpenApiDocument(options: { version?: string; serverUrl?: string } = {}) {
   const localhost = "http://localhost:3000";
@@ -129,10 +150,19 @@ export function buildOpenApiDocument(options: { version?: string; serverUrl?: st
       },
       schemas: {
         Error: toSchema(errorResponseSchema),
+        ReorderBody: toSchema(reorderBodySchema),
         EvaluationItem: toSchema(evaluationItemResponseSchema),
         EvaluationItemList: toSchema(evaluationItemListResponseSchema),
         EvaluationItemsImport: toSchema(evaluationItemsImportBodySchema),
         EvaluationItemsImportResult: toSchema(evaluationItemsImportResponseSchema),
+        Target: toSchema(targetResponseSchema),
+        TargetList: toSchema(targetListResponseSchema),
+        TargetCreate: toSchema(targetCreateBodySchema),
+        TargetUpdate: toSchema(targetUpdateBodySchema),
+        Category: toSchema(categoryResponseSchema),
+        CategoryList: toSchema(categoryListResponseSchema),
+        CategoryCreate: toSchema(categoryCreateBodySchema),
+        CategoryUpdate: toSchema(categoryUpdateBodySchema),
       },
     },
     paths: {
@@ -156,6 +186,149 @@ export function buildOpenApiDocument(options: { version?: string; serverUrl?: st
             401: errorResponse("認証エラー"),
             403: errorResponse("ADMIN 権限が必要"),
             409: errorResponse("no が重複"),
+          },
+        },
+      },
+      "/api/targets": {
+        get: {
+          summary: "大分類一覧を取得",
+          tags: ["targets"],
+          responses: {
+            200: jsonResponse("大分類の一覧", ref("TargetList")),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+          },
+        },
+        post: {
+          summary: "大分類を作成",
+          tags: ["targets"],
+          requestBody: jsonBody("TargetCreate"),
+          responses: {
+            201: jsonResponse("作成された大分類", ref("Target")),
+            400: errorResponse("バリデーションエラー"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            409: errorResponse("no 重複"),
+          },
+        },
+      },
+      "/api/targets/reorder": {
+        post: {
+          summary: "大分類の表示順を一括更新",
+          tags: ["targets"],
+          requestBody: jsonBody("ReorderBody"),
+          responses: {
+            200: { description: "並び替え成功（ボディなし）" },
+            400: errorResponse("バリデーションエラー"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("並び替え対象が未存在"),
+          },
+        },
+      },
+      "/api/targets/{id}": {
+        patch: {
+          summary: "大分類を更新（名称・no）",
+          tags: ["targets"],
+          parameters: [idParam],
+          requestBody: jsonBody("TargetUpdate"),
+          responses: {
+            200: jsonResponse("更新後の大分類", ref("Target")),
+            400: errorResponse("バリデーションエラー"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("未存在"),
+            409: errorResponse("no 重複"),
+          },
+        },
+        delete: {
+          summary: "大分類を削除",
+          tags: ["targets"],
+          parameters: [idParam],
+          responses: {
+            204: { description: "削除成功（ボディなし）" },
+            400: errorResponse("id 不正"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("未存在"),
+            409: errorResponse("紐づく中分類が存在"),
+          },
+        },
+      },
+      "/api/categories": {
+        get: {
+          summary: "中分類一覧を取得",
+          tags: ["categories"],
+          parameters: [
+            {
+              name: "targetId",
+              in: "query",
+              required: false,
+              schema: { type: "integer" },
+              description: "指定した大分類 ID で絞り込む",
+            },
+          ],
+          responses: {
+            200: jsonResponse("中分類の一覧", ref("CategoryList")),
+            400: errorResponse("targetId 不正"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+          },
+        },
+        post: {
+          summary: "中分類を作成",
+          tags: ["categories"],
+          requestBody: jsonBody("CategoryCreate"),
+          responses: {
+            201: jsonResponse("作成された中分類", ref("Category")),
+            400: errorResponse("バリデーションエラー"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("指定した targetId の大分類が未存在"),
+            409: errorResponse("no 重複"),
+          },
+        },
+      },
+      "/api/categories/reorder": {
+        post: {
+          summary: "中分類の表示順を一括更新",
+          tags: ["categories"],
+          requestBody: jsonBody("ReorderBody"),
+          responses: {
+            200: { description: "並び替え成功（ボディなし）" },
+            400: errorResponse("バリデーションエラー"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("並び替え対象が未存在"),
+          },
+        },
+      },
+      "/api/categories/{id}": {
+        patch: {
+          summary: "中分類を更新（名称・no）",
+          tags: ["categories"],
+          parameters: [idParam],
+          requestBody: jsonBody("CategoryUpdate"),
+          responses: {
+            200: jsonResponse("更新後の中分類", ref("Category")),
+            400: errorResponse("バリデーションエラー"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("未存在"),
+            409: errorResponse("no 重複"),
+          },
+        },
+        delete: {
+          summary: "中分類を削除",
+          tags: ["categories"],
+          parameters: [idParam],
+          responses: {
+            204: { description: "削除成功（ボディなし）" },
+            400: errorResponse("id 不正"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("未存在"),
+            409: errorResponse("紐づく評価項目が存在"),
           },
         },
       },

--- a/src/lib/schemas/category.ts
+++ b/src/lib/schemas/category.ts
@@ -1,5 +1,16 @@
 import { z } from "zod";
 
+/** 非空の名称フィールド（空文字・空白のみを弾く）。 */
+const nameField = z
+  .string({ error: "name は必須です" })
+  .refine((v) => v.trim().length > 0, { error: "name は必須です" });
+
+/** 管理番号フィールド（1 以上の整数）。 */
+const noField = z
+  .number({ error: "no は数値で指定してください" })
+  .int({ error: "no は整数で指定してください" })
+  .min(1, { error: "no は 1 以上で指定してください" });
+
 /**
  * 中分類の作成 body。`targetId`（所属大分類）と `name` が必須。
  * no・index は lib（`createCategory`）が自動採番する。
@@ -8,23 +19,25 @@ export const categoryCreateBodySchema = z.object(
   {
     targetId: z
       .number({ error: "targetId は必須です" })
-      .int({ error: "targetId は整数で指定してください" }),
-    name: z.string({ error: "name は必須です" }),
+      .int({ error: "targetId は整数で指定してください" })
+      .min(1, { error: "targetId は 1 以上で指定してください" }),
+    name: nameField,
   },
   { error: "リクエストボディが不正です" },
 );
 
-/** 中分類の更新 body（name・no は任意）。 */
-export const categoryUpdateBodySchema = z.object(
-  {
-    name: z.string({ error: "name は文字列で指定してください" }).optional(),
-    no: z
-      .number({ error: "no は数値で指定してください" })
-      .int({ error: "no は整数で指定してください" })
-      .optional(),
-  },
-  { error: "リクエストボディが不正です" },
-);
+/** 中分類の更新 body（name・no は任意だが、少なくとも一方を指定）。 */
+export const categoryUpdateBodySchema = z
+  .object(
+    {
+      name: nameField.optional(),
+      no: noField.optional(),
+    },
+    { error: "リクエストボディが不正です" },
+  )
+  .refine((d) => d.name !== undefined || d.no !== undefined, {
+    error: "name または no を指定してください",
+  });
 
 /** 中分類のレスポンス形式。 */
 export const categoryResponseSchema = z.object({

--- a/src/lib/schemas/category.ts
+++ b/src/lib/schemas/category.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+/**
+ * 中分類の作成 body。`targetId`（所属大分類）と `name` が必須。
+ * no・index は lib（`createCategory`）が自動採番する。
+ */
+export const categoryCreateBodySchema = z.object(
+  {
+    targetId: z
+      .number({ error: "targetId は必須です" })
+      .int({ error: "targetId は整数で指定してください" }),
+    name: z.string({ error: "name は必須です" }),
+  },
+  { error: "リクエストボディが不正です" },
+);
+
+/** 中分類の更新 body（name・no は任意）。 */
+export const categoryUpdateBodySchema = z.object(
+  {
+    name: z.string({ error: "name は文字列で指定してください" }).optional(),
+    no: z
+      .number({ error: "no は数値で指定してください" })
+      .int({ error: "no は整数で指定してください" })
+      .optional(),
+  },
+  { error: "リクエストボディが不正です" },
+);
+
+/** 中分類のレスポンス形式。 */
+export const categoryResponseSchema = z.object({
+  id: z.number().int(),
+  targetId: z.number().int(),
+  name: z.string(),
+  no: z.number().int(),
+  index: z.number().int(),
+});
+
+/** GET /api/categories のレスポンス（一覧ラッパ）。 */
+export const categoryListResponseSchema = z.object({
+  categories: z.array(categoryResponseSchema),
+});

--- a/src/lib/schemas/common.ts
+++ b/src/lib/schemas/common.ts
@@ -2,3 +2,24 @@ import { z } from "zod";
 
 /** エラーレスポンス `{ error: string }`（OpenAPI ドキュメント用）。 */
 export const errorResponseSchema = z.object({ error: z.string() });
+
+/**
+ * 並び替え（reorder）の body スキーマ。`{ orders: [{ id, index }] }`。
+ * targets / categories / evaluation-items で共用する。id・index は整数。
+ */
+export const reorderBodySchema = z.object(
+  {
+    orders: z
+      .array(
+        z.object({
+          id: z.number({ error: "id は必須です" }).int({ error: "id は整数で指定してください" }),
+          index: z
+            .number({ error: "index は必須です" })
+            .int({ error: "index は整数で指定してください" }),
+        }),
+        { error: "orders は配列で指定してください" },
+      )
+      .min(1, { error: "orders は必須です" }),
+  },
+  { error: "リクエストボディが不正です" },
+);

--- a/src/lib/schemas/target.ts
+++ b/src/lib/schemas/target.ts
@@ -1,25 +1,36 @@
 import { z } from "zod";
 
+/** 非空の名称フィールド（空文字・空白のみを弾く）。 */
+const nameField = z
+  .string({ error: "name は必須です" })
+  .refine((v) => v.trim().length > 0, { error: "name は必須です" });
+
+/** 管理番号フィールド（1 以上の整数）。 */
+const noField = z
+  .number({ error: "no は数値で指定してください" })
+  .int({ error: "no は整数で指定してください" })
+  .min(1, { error: "no は 1 以上で指定してください" });
+
 /**
- * 大分類の作成 body。route の責務は「`name` が文字列か」の検証のみ。
- * no・index は lib（`createTarget`）が自動採番する。
+ * 大分類の作成 body。no・index は lib（`createTarget`）が自動採番する。
  */
 export const targetCreateBodySchema = z.object(
-  { name: z.string({ error: "name は必須です" }) },
+  { name: nameField },
   { error: "リクエストボディが不正です" },
 );
 
-/** 大分類の更新 body（name・no は任意。少なくとも一方を指定）。 */
-export const targetUpdateBodySchema = z.object(
-  {
-    name: z.string({ error: "name は文字列で指定してください" }).optional(),
-    no: z
-      .number({ error: "no は数値で指定してください" })
-      .int({ error: "no は整数で指定してください" })
-      .optional(),
-  },
-  { error: "リクエストボディが不正です" },
-);
+/** 大分類の更新 body（name・no は任意だが、少なくとも一方を指定）。 */
+export const targetUpdateBodySchema = z
+  .object(
+    {
+      name: nameField.optional(),
+      no: noField.optional(),
+    },
+    { error: "リクエストボディが不正です" },
+  )
+  .refine((d) => d.name !== undefined || d.no !== undefined, {
+    error: "name または no を指定してください",
+  });
 
 /** 大分類のレスポンス形式。 */
 export const targetResponseSchema = z.object({

--- a/src/lib/schemas/target.ts
+++ b/src/lib/schemas/target.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+/**
+ * 大分類の作成 body。route の責務は「`name` が文字列か」の検証のみ。
+ * no・index は lib（`createTarget`）が自動採番する。
+ */
+export const targetCreateBodySchema = z.object(
+  { name: z.string({ error: "name は必須です" }) },
+  { error: "リクエストボディが不正です" },
+);
+
+/** 大分類の更新 body（name・no は任意。少なくとも一方を指定）。 */
+export const targetUpdateBodySchema = z.object(
+  {
+    name: z.string({ error: "name は文字列で指定してください" }).optional(),
+    no: z
+      .number({ error: "no は数値で指定してください" })
+      .int({ error: "no は整数で指定してください" })
+      .optional(),
+  },
+  { error: "リクエストボディが不正です" },
+);
+
+/** 大分類のレスポンス形式。 */
+export const targetResponseSchema = z.object({
+  id: z.number().int(),
+  name: z.string(),
+  no: z.number().int(),
+  index: z.number().int(),
+});
+
+/** GET /api/targets のレスポンス（一覧ラッパ）。 */
+export const targetListResponseSchema = z.object({
+  targets: z.array(targetResponseSchema),
+});


### PR DESCRIPTION
## Summary

外部 REST API 化 epic（#13 / まとめブランチ `feature/rest-api`）の第2フェーズ。評価項目マスタの階層（大分類 targets / 中分類 categories）を REST API 化する。T211 で確立した契約を踏襲。

### 追加エンドポイント（すべて ADMIN 認可）

**targets**
- `GET /api/targets` / `POST /api/targets`（201）
- `PATCH /api/targets/{id}` / `DELETE /api/targets/{id}`（204）
- `POST /api/targets/reorder`

**categories**
- `GET /api/categories?targetId=` / `POST /api/categories`（201）
- `PATCH /api/categories/{id}` / `DELETE /api/categories/{id}`（204）
- `POST /api/categories/reorder`

### 実装

- **Zod 単一ソース**: `schemas/target.ts`・`schemas/category.ts`（create/update/response/list）、`common.ts` に共通の `reorderBodySchema`（`{ orders: { id, index }[] }`）
- **lib 委譲**: 既存 `targets.ts`・`categories.ts` を呼ぶ薄いアダプタ。業務ロジック・トランザクションは lib のまま
- **エラー**: 型付きエラー → `statusForError`（404/403/409/400）、想定外 → `jsonErrorFromException`（500 固定文言）。削除は子要素があると 409
- **serialize**: `api-response.ts` に `serializeTarget` / `serializeCategory`
- **OpenAPI**: `document.ts` に targets/categories の paths・schemas を追記（7 パス / 12 オペレーション）。`{id}` は整数 path param

## Test plan

- [x] ユニットテスト 318 passed（各ルート 200/201/204/400/401/403/404/409）
- [x] `next build` で 6 ルート登録確認
- [x] 実 API キーで読み取り検証（キーなし 401 / ADMIN 200 / MEMBER 403 / `?targetId=` 絞り込み） — [結果コメント](https://github.com/ot-nemoto/eval-hub/issues/387#issuecomment-4978873382)
- [x] `/api-reference` に targets/categories 表示を確認

## 備考

- base は **まとめブランチ `feature/rest-api`**。develop へは全フェーズ完了後に単一 PR。
- 書き込み系（POST/PATCH/DELETE/reorder）は実マスタを変更するためライブ検証は未実施（ユニットテストでカバー）。

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)