### PR TITLE
[T213] evaluation-items の単体 CRUD 追加・一括インポート移設

### DIFF
--- a/src/app/api/evaluation-items/[id]/route.test.ts
+++ b/src/app/api/evaluation-items/[id]/route.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/evaluation-items", () => ({
+  updateEvaluationItem: vi.fn(),
+  deleteEvaluationItem: vi.fn(),
+}));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { BadRequestError, ConflictError, NotFoundError } from "@/lib/errors";
+import { deleteEvaluationItem, updateEvaluationItem } from "@/lib/evaluation-items";
+import { DELETE, PATCH } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+
+const libItem = {
+  id: 1,
+  targetId: 1,
+  categoryId: 1,
+  no: 2,
+  name: "更新後",
+  description: null,
+  evalCriteria: null,
+  target: { id: 1, name: "社員", no: 1 },
+  category: { id: 1, targetId: 1, name: "エンゲージメント", no: 1 },
+};
+
+function makeRequest(method: string, body?: unknown) {
+  return new Request("http://localhost/api/evaluation-items/1", {
+    method,
+    headers: { "Content-Type": "application/json", authorization: "Bearer key" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  }) as import("next/server").NextRequest;
+}
+
+const ctx = (id = "1") => ({ params: Promise.resolve({ id }) });
+
+describe("PATCH /api/evaluation-items/[id]", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("更新して 200 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(updateEvaluationItem).mockResolvedValue(libItem as never);
+
+    const res = await PATCH(makeRequest("PATCH", { name: "更新後", no: 2 }), ctx());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.name).toBe("更新後");
+    expect(updateEvaluationItem).toHaveBeenCalledWith(1, { name: "更新後", no: 2 });
+  });
+
+  it("空 body は 400（lib が BadRequest）", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(updateEvaluationItem).mockRejectedValue(
+      new BadRequestError("更新するフィールドを指定してください"),
+    );
+    expect((await PATCH(makeRequest("PATCH", {}), ctx())).status).toBe(400);
+  });
+
+  it("未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(updateEvaluationItem).mockRejectedValue(
+      new NotFoundError("評価項目が見つかりません"),
+    );
+    expect((await PATCH(makeRequest("PATCH", { name: "x" }), ctx())).status).toBe(404);
+  });
+
+  it("no 重複は 409", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(updateEvaluationItem).mockRejectedValue(
+      new ConflictError("同じ中分類内に同じ no の評価項目がすでに存在します"),
+    );
+    expect((await PATCH(makeRequest("PATCH", { no: 3 }), ctx())).status).toBe(409);
+  });
+
+  it("no が 0 以下は 400（Zod）", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await PATCH(makeRequest("PATCH", { no: 0 }), ctx())).status).toBe(400);
+    expect(updateEvaluationItem).not.toHaveBeenCalled();
+  });
+
+  it("id 不正は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await PATCH(makeRequest("PATCH", { name: "x" }), ctx("abc"))).status).toBe(400);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await PATCH(makeRequest("PATCH", { name: "x" }), ctx())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await PATCH(makeRequest("PATCH", { name: "x" }), ctx())).status).toBe(403);
+  });
+});
+
+describe("DELETE /api/evaluation-items/[id]", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("削除して 204 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(deleteEvaluationItem).mockResolvedValue(undefined);
+
+    const res = await DELETE(makeRequest("DELETE"), ctx());
+    expect(res.status).toBe(204);
+    expect(deleteEvaluationItem).toHaveBeenCalledWith(1);
+  });
+
+  it("未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(deleteEvaluationItem).mockRejectedValue(
+      new NotFoundError("評価項目が見つかりません"),
+    );
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(404);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(403);
+  });
+});

--- a/src/app/api/evaluation-items/[id]/route.ts
+++ b/src/app/api/evaluation-items/[id]/route.ts
@@ -1,0 +1,56 @@
+import { type NextRequest, NextResponse } from "next/server";
+import {
+  jsonError,
+  jsonErrorFromException,
+  serializeEvaluationItem,
+  unauthorized,
+} from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { deleteEvaluationItem, updateEvaluationItem } from "@/lib/evaluation-items";
+import { firstZodError } from "@/lib/schemas/_zod-error";
+import { evaluationItemUpdateBodySchema } from "@/lib/schemas/evaluation-item";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+function parseId(id: string): number | null {
+  const n = Number(id);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+export async function PATCH(req: NextRequest, { params }: RouteContext) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const { id } = await params;
+  const itemId = parseId(id);
+  if (itemId === null) return jsonError("id は正の整数で指定してください", 400);
+
+  const body = await req.json().catch(() => null);
+  const parsed = evaluationItemUpdateBodySchema.safeParse(body);
+  if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
+
+  try {
+    const item = await updateEvaluationItem(itemId, parsed.data);
+    return NextResponse.json(serializeEvaluationItem(item));
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: RouteContext) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const { id } = await params;
+  const itemId = parseId(id);
+  if (itemId === null) return jsonError("id は正の整数で指定してください", 400);
+
+  try {
+    await deleteEvaluationItem(itemId);
+    return new NextResponse(null, { status: 204 });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/app/api/evaluation-items/import/route.test.ts
+++ b/src/app/api/evaluation-items/import/route.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/evaluation-items", () => ({ bulkReplaceEvaluationItems: vi.fn() }));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { ConflictError } from "@/lib/errors";
+import { bulkReplaceEvaluationItems } from "@/lib/evaluation-items";
+import { POST } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+
+function makeRequest(body?: unknown) {
+  return new Request("http://localhost/api/evaluation-items/import", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", authorization: "Bearer key" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  }) as import("next/server").NextRequest;
+}
+
+const validBody = [
+  {
+    no: 1,
+    name: "社員",
+    categories: [{ no: 1, name: "エンゲージメント", items: [{ no: 1, name: "item A" }] }],
+  },
+];
+
+describe("POST /api/evaluation-items/import", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("一括インポートして作成件数を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(bulkReplaceEvaluationItems).mockResolvedValue({ created: 1 });
+
+    const res = await POST(makeRequest(validBody));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ created: 1 });
+    expect(bulkReplaceEvaluationItems).toHaveBeenCalledWith(validBody);
+  });
+
+  it("配列でない body は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makeRequest({ not: "array" }))).status).toBe(400);
+    expect(bulkReplaceEvaluationItems).not.toHaveBeenCalled();
+  });
+
+  it("空配列は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makeRequest([]))).status).toBe(400);
+  });
+
+  it("no 重複は 409", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(bulkReplaceEvaluationItems).mockRejectedValue(
+      new ConflictError("no が重複しています"),
+    );
+    expect((await POST(makeRequest(validBody))).status).toBe(409);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await POST(makeRequest(validBody))).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await POST(makeRequest(validBody))).status).toBe(403);
+  });
+});

--- a/src/app/api/evaluation-items/import/route.ts
+++ b/src/app/api/evaluation-items/import/route.ts
@@ -1,0 +1,23 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { jsonError, jsonErrorFromException, unauthorized } from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { bulkReplaceEvaluationItems } from "@/lib/evaluation-items";
+import { firstZodError } from "@/lib/schemas/_zod-error";
+import { evaluationItemsImportBodySchema } from "@/lib/schemas/evaluation-item";
+
+export async function POST(req: NextRequest) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const body = await req.json().catch(() => null);
+  const parsed = evaluationItemsImportBodySchema.safeParse(body);
+  if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
+
+  try {
+    const result = await bulkReplaceEvaluationItems(parsed.data);
+    return NextResponse.json(result);
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/app/api/evaluation-items/reorder/route.test.ts
+++ b/src/app/api/evaluation-items/reorder/route.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/evaluation-items", () => ({ reorderEvaluationItems: vi.fn() }));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { NotFoundError } from "@/lib/errors";
+import { reorderEvaluationItems } from "@/lib/evaluation-items";
+import { POST } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+
+function makeRequest(body?: unknown) {
+  return new Request("http://localhost/api/evaluation-items/reorder", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", authorization: "Bearer key" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  }) as import("next/server").NextRequest;
+}
+
+const validBody = {
+  orders: [
+    { id: 1, index: 2 },
+    { id: 2, index: 1 },
+  ],
+};
+
+describe("POST /api/evaluation-items/reorder", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("並び替えて 204 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(reorderEvaluationItems).mockResolvedValue(undefined);
+
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(204);
+    expect(reorderEvaluationItems).toHaveBeenCalledWith(validBody.orders);
+  });
+
+  it("orders 欠落は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makeRequest({}))).status).toBe(400);
+    expect(reorderEvaluationItems).not.toHaveBeenCalled();
+  });
+
+  it("対象未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(reorderEvaluationItems).mockRejectedValue(
+      new NotFoundError("並び替え対象の評価項目が見つかりません"),
+    );
+    expect((await POST(makeRequest(validBody))).status).toBe(404);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await POST(makeRequest(validBody))).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await POST(makeRequest(validBody))).status).toBe(403);
+  });
+});

--- a/src/app/api/evaluation-items/reorder/route.ts
+++ b/src/app/api/evaluation-items/reorder/route.ts
@@ -1,0 +1,23 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { jsonError, jsonErrorFromException, unauthorized } from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { reorderEvaluationItems } from "@/lib/evaluation-items";
+import { firstZodError } from "@/lib/schemas/_zod-error";
+import { reorderBodySchema } from "@/lib/schemas/common";
+
+export async function POST(req: NextRequest) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const body = await req.json().catch(() => null);
+  const parsed = reorderBodySchema.safeParse(body);
+  if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
+
+  try {
+    await reorderEvaluationItems(parsed.data.orders);
+    return new NextResponse(null, { status: 204 });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/app/api/evaluation-items/route.test.ts
+++ b/src/app/api/evaluation-items/route.test.ts
@@ -1,51 +1,32 @@
 // @vitest-environment node
-import { Prisma } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/lib/apiAuth", () => ({
-  getAuthenticatedUser: vi.fn(),
-}));
-
-vi.mock("@/lib/prisma", () => ({
-  prisma: {
-    evaluationItem: { findMany: vi.fn(), createMany: vi.fn(), deleteMany: vi.fn() },
-    target: { create: vi.fn(), deleteMany: vi.fn() },
-    category: { create: vi.fn(), deleteMany: vi.fn() },
-    $transaction: vi.fn((cb: (tx: unknown) => Promise<unknown>) =>
-      cb({
-        target: {
-          create: vi.mocked(prisma.target.create),
-          deleteMany: vi.mocked(prisma.target.deleteMany),
-        },
-        category: {
-          create: vi.mocked(prisma.category.create),
-          deleteMany: vi.mocked(prisma.category.deleteMany),
-        },
-        evaluationItem: {
-          createMany: vi.mocked(prisma.evaluationItem.createMany),
-          deleteMany: vi.mocked(prisma.evaluationItem.deleteMany),
-        },
-      }),
-    ),
-  },
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/evaluation-items", () => ({
+  getEvaluationItems: vi.fn(),
+  createEvaluationItem: vi.fn(),
 }));
 
 import { getAuthenticatedUser } from "@/lib/apiAuth";
-import { prisma } from "@/lib/prisma";
+import { BadRequestError, ConflictError, NotFoundError } from "@/lib/errors";
+import { createEvaluationItem, getEvaluationItems } from "@/lib/evaluation-items";
 import { GET, POST } from "./route";
 
 const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
 const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
 
-function makeRequest(body?: unknown) {
-  return new Request("http://localhost/api/evaluation-items", {
-    method: body !== undefined ? "POST" : "GET",
-    headers: { "Content-Type": "application/json", authorization: "Bearer key" },
-    body: body !== undefined ? JSON.stringify(body) : undefined,
-  }) as import("next/server").NextRequest;
-}
-
-const mockItem = {
+const libItem = {
+  id: 1,
+  targetId: 1,
+  categoryId: 1,
+  no: 1,
+  name: "item A",
+  description: null,
+  evalCriteria: null,
+  target: { id: 1, name: "社員", no: 1 },
+  category: { id: 1, targetId: 1, name: "エンゲージメント", no: 1 },
+};
+const serialized = {
   id: 1,
   no: 1,
   name: "item A",
@@ -55,182 +36,112 @@ const mockItem = {
   category: { id: 1, no: 1, name: "エンゲージメント" },
 };
 
+function makeGet(query = "") {
+  return new Request(`http://localhost/api/evaluation-items${query}`, {
+    method: "GET",
+    headers: { authorization: "Bearer key" },
+  }) as import("next/server").NextRequest;
+}
+function makePost(body: unknown) {
+  return new Request("http://localhost/api/evaluation-items", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", authorization: "Bearer key" },
+    body: JSON.stringify(body),
+  }) as import("next/server").NextRequest;
+}
+
 describe("GET /api/evaluation-items", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("ADMIN の場合は評価項目一覧を返す", async () => {
+  it("ADMIN は一覧を返す（フィルタなし）", async () => {
     vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
-    vi.mocked(prisma.evaluationItem.findMany).mockResolvedValue([mockItem] as never);
+    vi.mocked(getEvaluationItems).mockResolvedValue([libItem] as never);
 
-    const res = await GET(makeRequest());
+    const res = await GET(makeGet());
     const body = await res.json();
-
     expect(res.status).toBe(200);
-    expect(body.evaluationItems).toHaveLength(1);
-    expect(body.evaluationItems[0]).toEqual({
-      id: 1,
-      no: 1,
-      name: "item A",
-      description: null,
-      evalCriteria: null,
-      target: { id: 1, no: 1, name: "社員" },
-      category: { id: 1, no: 1, name: "エンゲージメント" },
-    });
+    expect(body).toEqual({ evaluationItems: [serialized] });
+    expect(getEvaluationItems).toHaveBeenCalledWith({ targetId: undefined, categoryId: undefined });
   });
 
-  it("API キーが無効な場合は 401 を返す", async () => {
-    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
-
-    const res = await GET(makeRequest());
-    const body = await res.json();
-    expect(res.status).toBe(401);
-    expect(typeof body.error).toBe("string");
-  });
-
-  it("MEMBER の場合は 403 を返す", async () => {
-    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
-
-    const res = await GET(makeRequest());
-    const body = await res.json();
-    expect(res.status).toBe(403);
-    expect(body.error).toBe("権限がありません");
-  });
-
-  it("想定外エラーは 500 で内部メッセージを隠す", async () => {
+  it("targetId・categoryId で絞り込む", async () => {
     vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
-    vi.mocked(prisma.evaluationItem.findMany).mockRejectedValue(
-      new Error("Prisma: connection refused at host db:5432"),
-    );
+    vi.mocked(getEvaluationItems).mockResolvedValue([] as never);
 
-    const res = await GET(makeRequest());
-    const body = await res.json();
-    expect(res.status).toBe(500);
-    expect(body.error).toBe("サーバーエラーが発生しました");
+    await GET(makeGet("?targetId=1&categoryId=2"));
+    expect(getEvaluationItems).toHaveBeenCalledWith({ targetId: 1, categoryId: 2 });
+  });
+
+  it("targetId 不正は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await GET(makeGet("?targetId=abc"))).status).toBe(400);
+    expect(getEvaluationItems).not.toHaveBeenCalled();
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await GET(makeGet())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await GET(makeGet())).status).toBe(403);
   });
 });
 
 describe("POST /api/evaluation-items", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  const validBody = [
-    {
-      no: 1,
-      name: "社員",
-      categories: [
-        {
-          no: 1,
-          name: "エンゲージメント",
-          items: [{ no: 1, name: "item A", description: null, evalCriteria: null }],
-        },
-      ],
-    },
-  ];
+  const validBody = { targetId: 1, categoryId: 1, name: "item A" };
 
-  it("有効なリクエストで全削除→INSERT を実行して作成件数を返す", async () => {
+  it("作成して 201 を返す", async () => {
     vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
-    vi.mocked(prisma.target.create).mockResolvedValue({ id: 1, no: 1, name: "社員" } as never);
-    vi.mocked(prisma.category.create).mockResolvedValue({
-      id: 1,
-      targetId: 1,
-      no: 1,
-      name: "エンゲージメント",
-    } as never);
-    vi.mocked(prisma.evaluationItem.createMany).mockResolvedValue({ count: 1 } as never);
+    vi.mocked(createEvaluationItem).mockResolvedValue(libItem as never);
 
-    const res = await POST(makeRequest(validBody));
+    const res = await POST(makePost(validBody));
     const body = await res.json();
-
-    expect(res.status).toBe(200);
-    expect(body.created).toBe(1);
-    expect(prisma.evaluationItem.deleteMany).toHaveBeenCalledTimes(1);
-    expect(prisma.category.deleteMany).toHaveBeenCalledTimes(1);
-    expect(prisma.target.deleteMany).toHaveBeenCalledTimes(1);
-    expect(prisma.target.create).toHaveBeenCalledTimes(1);
-    expect(prisma.category.create).toHaveBeenCalledTimes(1);
-    expect(prisma.evaluationItem.createMany).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(201);
+    expect(body).toEqual(serialized);
+    expect(createEvaluationItem).toHaveBeenCalledWith(
+      expect.objectContaining({ targetId: 1, categoryId: 1, name: "item A" }),
+    );
   });
 
-  it("API キーが無効な場合は 401 を返す", async () => {
+  it("name 欠落・空文字は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makePost({ targetId: 1, categoryId: 1 }))).status).toBe(400);
+    expect((await POST(makePost({ targetId: 1, categoryId: 1, name: "  " }))).status).toBe(400);
+    expect(createEvaluationItem).not.toHaveBeenCalled();
+  });
+
+  it("targetId 欠落は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makePost({ categoryId: 1, name: "x" }))).status).toBe(400);
+  });
+
+  it("所属が未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(createEvaluationItem).mockRejectedValue(new NotFoundError("大分類が見つかりません"));
+    expect((await POST(makePost(validBody))).status).toBe(404);
+  });
+
+  it("categoryId が targetId と不整合は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(createEvaluationItem).mockRejectedValue(
+      new BadRequestError("categoryId が targetId と一致しません"),
+    );
+    expect((await POST(makePost(validBody))).status).toBe(400);
+  });
+
+  it("同名重複は 409", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(createEvaluationItem).mockRejectedValue(
+      new ConflictError("同じ名称の評価項目が既に存在します"),
+    );
+    expect((await POST(makePost(validBody))).status).toBe(409);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
     vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
-
-    const res = await POST(makeRequest(validBody));
-    expect(res.status).toBe(401);
-  });
-
-  it("MEMBER の場合は 403 を返す", async () => {
+    expect((await POST(makePost(validBody))).status).toBe(401);
     vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
-
-    const res = await POST(makeRequest(validBody));
-    expect(res.status).toBe(403);
-  });
-
-  it("配列でない body は 400 を返す", async () => {
-    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
-
-    const res = await POST(makeRequest({ not: "array" }));
-    const body = await res.json();
-    expect(res.status).toBe(400);
-    expect(typeof body.error).toBe("string");
-  });
-
-  it("空配列は 400 を返す", async () => {
-    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
-
-    const res = await POST(makeRequest([]));
-    expect(res.status).toBe(400);
-  });
-
-  it("大項目に name がない場合は 400 を返す（Zod 構造検証）", async () => {
-    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
-
-    const res = await POST(makeRequest([{ no: 1, categories: [] }]));
-    expect(res.status).toBe(400);
-  });
-
-  it("中項目に no がない場合は 400 を返す（Zod 構造検証）", async () => {
-    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
-
-    const res = await POST(
-      makeRequest([{ no: 1, name: "T", categories: [{ name: "C", items: [] }] }]),
-    );
-    expect(res.status).toBe(400);
-  });
-
-  it("no が 0 以下の場合は 400 を返す（lib 業務検証）", async () => {
-    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
-
-    const res = await POST(makeRequest([{ no: 0, name: "T", categories: [] }]));
-    const body = await res.json();
-    expect(res.status).toBe(400);
-    expect(body.error).toContain("1以上の整数");
-  });
-
-  it("不正な JSON は 400 を返す", async () => {
-    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
-
-    const req = new Request("http://localhost/api/evaluation-items", {
-      method: "POST",
-      headers: { "Content-Type": "application/json", authorization: "Bearer key" },
-      body: "not-json",
-    }) as import("next/server").NextRequest;
-
-    const res = await POST(req);
-    expect(res.status).toBe(400);
-  });
-
-  it("no 重複（P2002）は 409 を返す", async () => {
-    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
-    vi.mocked(prisma.target.create).mockRejectedValue(
-      new Prisma.PrismaClientKnownRequestError("Unique constraint", {
-        code: "P2002",
-        clientVersion: "5.0.0",
-      }),
-    );
-
-    const res = await POST(makeRequest(validBody));
-    const body = await res.json();
-
-    expect(res.status).toBe(409);
-    expect(body.error).toBe("no が重複しています");
+    expect((await POST(makePost(validBody))).status).toBe(403);
   });
 });

--- a/src/app/api/evaluation-items/route.ts
+++ b/src/app/api/evaluation-items/route.ts
@@ -6,17 +6,29 @@ import {
   unauthorized,
 } from "@/lib/api-response";
 import { getAuthenticatedUser } from "@/lib/apiAuth";
-import { bulkReplaceEvaluationItems, getEvaluationItems } from "@/lib/evaluation-items";
+import { createEvaluationItem, getEvaluationItems } from "@/lib/evaluation-items";
 import { firstZodError } from "@/lib/schemas/_zod-error";
-import { evaluationItemsImportBodySchema } from "@/lib/schemas/evaluation-item";
+import { evaluationItemCreateBodySchema } from "@/lib/schemas/evaluation-item";
+
+function parsePositiveInt(value: string | null): number | undefined | null {
+  if (value === null) return undefined;
+  const n = Number(value);
+  return Number.isInteger(n) && n >= 1 ? n : null;
+}
 
 export async function GET(req: NextRequest) {
   const user = await getAuthenticatedUser(req);
   if (!user) return unauthorized();
   if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
 
+  const params = new URL(req.url).searchParams;
+  const targetId = parsePositiveInt(params.get("targetId"));
+  if (targetId === null) return jsonError("targetId は 1 以上の整数で指定してください", 400);
+  const categoryId = parsePositiveInt(params.get("categoryId"));
+  if (categoryId === null) return jsonError("categoryId は 1 以上の整数で指定してください", 400);
+
   try {
-    const items = await getEvaluationItems();
+    const items = await getEvaluationItems({ targetId, categoryId });
     return NextResponse.json({ evaluationItems: items.map(serializeEvaluationItem) });
   } catch (e) {
     return jsonErrorFromException(e);
@@ -29,12 +41,12 @@ export async function POST(req: NextRequest) {
   if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
 
   const body = await req.json().catch(() => null);
-  const parsed = evaluationItemsImportBodySchema.safeParse(body);
+  const parsed = evaluationItemCreateBodySchema.safeParse(body);
   if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
 
   try {
-    const result = await bulkReplaceEvaluationItems(parsed.data);
-    return NextResponse.json(result);
+    const item = await createEvaluationItem(parsed.data);
+    return NextResponse.json(serializeEvaluationItem(item), { status: 201 });
   } catch (e) {
     return jsonErrorFromException(e);
   }

--- a/src/lib/openapi/document.test.ts
+++ b/src/lib/openapi/document.test.ts
@@ -6,6 +6,9 @@ const doc = buildOpenApiDocument({ version: "9.9.9" });
 
 const EXPECTED_PATHS = [
   "/api/evaluation-items",
+  "/api/evaluation-items/import",
+  "/api/evaluation-items/reorder",
+  "/api/evaluation-items/{id}",
   "/api/targets",
   "/api/targets/reorder",
   "/api/targets/{id}",
@@ -59,7 +62,7 @@ describe("buildOpenApiDocument", () => {
       (n, item) => n + Object.keys(item).filter((k) => HTTP_METHODS.includes(k)).length,
       0,
     );
-    expect(opCount).toBe(12);
+    expect(opCount).toBe(16);
   });
 
   it("各オペレーションに summary と responses がある", () => {
@@ -83,6 +86,8 @@ describe("buildOpenApiDocument", () => {
         "ReorderBody",
         "EvaluationItem",
         "EvaluationItemList",
+        "EvaluationItemCreate",
+        "EvaluationItemUpdate",
         "EvaluationItemsImport",
         "EvaluationItemsImportResult",
         "Target",

--- a/src/lib/openapi/document.ts
+++ b/src/lib/openapi/document.ts
@@ -7,10 +7,12 @@ import {
 } from "@/lib/schemas/category";
 import { errorResponseSchema, reorderBodySchema } from "@/lib/schemas/common";
 import {
+  evaluationItemCreateBodySchema,
   evaluationItemListResponseSchema,
   evaluationItemResponseSchema,
   evaluationItemsImportBodySchema,
   evaluationItemsImportResponseSchema,
+  evaluationItemUpdateBodySchema,
 } from "@/lib/schemas/evaluation-item";
 import {
   targetCreateBodySchema,
@@ -153,6 +155,8 @@ export function buildOpenApiDocument(options: { version?: string; serverUrl?: st
         ReorderBody: toSchema(reorderBodySchema),
         EvaluationItem: toSchema(evaluationItemResponseSchema),
         EvaluationItemList: toSchema(evaluationItemListResponseSchema),
+        EvaluationItemCreate: toSchema(evaluationItemCreateBodySchema),
+        EvaluationItemUpdate: toSchema(evaluationItemUpdateBodySchema),
         EvaluationItemsImport: toSchema(evaluationItemsImportBodySchema),
         EvaluationItemsImportResult: toSchema(evaluationItemsImportResponseSchema),
         Target: toSchema(targetResponseSchema),
@@ -170,12 +174,44 @@ export function buildOpenApiDocument(options: { version?: string; serverUrl?: st
         get: {
           summary: "評価項目一覧を取得",
           tags: ["evaluation-items"],
+          parameters: [
+            {
+              name: "targetId",
+              in: "query",
+              required: false,
+              schema: { type: "integer" },
+              description: "大分類 ID で絞り込む",
+            },
+            {
+              name: "categoryId",
+              in: "query",
+              required: false,
+              schema: { type: "integer" },
+              description: "中分類 ID で絞り込む",
+            },
+          ],
           responses: {
             200: jsonResponse("評価項目の一覧", ref("EvaluationItemList")),
+            400: errorResponse("クエリ不正"),
             401: errorResponse("認証エラー"),
             403: errorResponse("ADMIN 権限が必要"),
           },
         },
+        post: {
+          summary: "評価項目を作成",
+          tags: ["evaluation-items"],
+          requestBody: jsonBody("EvaluationItemCreate"),
+          responses: {
+            201: jsonResponse("作成された評価項目", ref("EvaluationItem")),
+            400: errorResponse("バリデーションエラー / categoryId が targetId と不整合"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("指定した大分類・中分類が未存在"),
+            409: errorResponse("no 重複"),
+          },
+        },
+      },
+      "/api/evaluation-items/import": {
         post: {
           summary: "評価項目マスタを一括インポート（全削除→INSERT）",
           tags: ["evaluation-items"],
@@ -186,6 +222,48 @@ export function buildOpenApiDocument(options: { version?: string; serverUrl?: st
             401: errorResponse("認証エラー"),
             403: errorResponse("ADMIN 権限が必要"),
             409: errorResponse("no が重複"),
+          },
+        },
+      },
+      "/api/evaluation-items/reorder": {
+        post: {
+          summary: "評価項目の表示順を一括更新",
+          tags: ["evaluation-items"],
+          requestBody: jsonBody("ReorderBody"),
+          responses: {
+            204: { description: "並び替え成功（ボディなし）" },
+            400: errorResponse("バリデーションエラー"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("並び替え対象が未存在"),
+          },
+        },
+      },
+      "/api/evaluation-items/{id}": {
+        patch: {
+          summary: "評価項目を更新",
+          tags: ["evaluation-items"],
+          parameters: [idParam],
+          requestBody: jsonBody("EvaluationItemUpdate"),
+          responses: {
+            200: jsonResponse("更新後の評価項目", ref("EvaluationItem")),
+            400: errorResponse("バリデーションエラー / 更新フィールドなし"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("未存在"),
+            409: errorResponse("no 重複"),
+          },
+        },
+        delete: {
+          summary: "評価項目を削除",
+          tags: ["evaluation-items"],
+          parameters: [idParam],
+          responses: {
+            204: { description: "削除成功（ボディなし）" },
+            400: errorResponse("id 不正"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("未存在"),
           },
         },
       },

--- a/src/lib/schemas/category.ts
+++ b/src/lib/schemas/category.ts
@@ -1,15 +1,5 @@
 import { z } from "zod";
-
-/** 非空の名称フィールド（空文字・空白のみを弾く）。 */
-const nameField = z
-  .string({ error: "name は必須です" })
-  .refine((v) => v.trim().length > 0, { error: "name は必須です" });
-
-/** 管理番号フィールド（1 以上の整数）。 */
-const noField = z
-  .number({ error: "no は数値で指定してください" })
-  .int({ error: "no は整数で指定してください" })
-  .min(1, { error: "no は 1 以上で指定してください" });
+import { nameField, positiveIntField } from "@/lib/schemas/common";
 
 /**
  * 中分類の作成 body。`targetId`（所属大分類）と `name` が必須。
@@ -17,10 +7,7 @@ const noField = z
  */
 export const categoryCreateBodySchema = z.object(
   {
-    targetId: z
-      .number({ error: "targetId は必須です" })
-      .int({ error: "targetId は整数で指定してください" })
-      .min(1, { error: "targetId は 1 以上で指定してください" }),
+    targetId: positiveIntField("targetId"),
     name: nameField,
   },
   { error: "リクエストボディが不正です" },
@@ -31,7 +18,7 @@ export const categoryUpdateBodySchema = z
   .object(
     {
       name: nameField.optional(),
-      no: noField.optional(),
+      no: positiveIntField("no").optional(),
     },
     { error: "リクエストボディが不正です" },
   )

--- a/src/lib/schemas/common.ts
+++ b/src/lib/schemas/common.ts
@@ -3,6 +3,24 @@ import { z } from "zod";
 /** エラーレスポンス `{ error: string }`（OpenAPI ドキュメント用）。 */
 export const errorResponseSchema = z.object({ error: z.string() });
 
+/** 非空の名称フィールド（空文字・空白のみを弾く）。REST 各リソースで共用。 */
+export const nameField = z
+  .string({ error: "name は必須です" })
+  .refine((v) => v.trim().length > 0, { error: "name は必須です" });
+
+/**
+ * 1 以上の整数フィールド（`no`・`targetId`・`categoryId` 等で共用）。
+ * 未指定・型不一致・非整数・範囲外で文言を分ける。
+ */
+export const positiveIntField = (label: string) =>
+  z
+    .number({
+      error: (iss) =>
+        iss.input === undefined ? `${label} は必須です` : `${label} は数値で指定してください`,
+    })
+    .int({ error: `${label} は整数で指定してください` })
+    .min(1, { error: `${label} は 1 以上で指定してください` });
+
 /**
  * 並び替え（reorder）の body スキーマ。`{ orders: [{ id, index }] }`。
  * targets / categories / evaluation-items で共用する。id・index は整数。

--- a/src/lib/schemas/evaluation-item.ts
+++ b/src/lib/schemas/evaluation-item.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 /**
- * 評価項目一括インポート（POST /api/evaluation-items）の body スキーマ。
+ * 評価項目一括インポート（POST /api/evaluation-items/import）の body スキーマ。
  * 大項目（Target）→ 中項目（Category）→ 評価項目（EvaluationItem）の階層構造。
  * route の責務は「型・構造の検証」のみ。no≥1・name 非空・no 重複(409) の判定は
  * lib（`bulkReplaceEvaluationItems`）が担う。
@@ -57,3 +57,44 @@ export const evaluationItemResponseSchema = z.object({
 export const evaluationItemListResponseSchema = z.object({
   evaluationItems: z.array(evaluationItemResponseSchema),
 });
+
+/** 非空の名称フィールド（空文字・空白のみを弾く）。 */
+const nameField = z
+  .string({ error: "name は必須です" })
+  .refine((v) => v.trim().length > 0, { error: "name は必須です" });
+
+const positiveIntField = (label: string) =>
+  z
+    .number({ error: `${label} は数値で指定してください` })
+    .int({ error: `${label} は整数で指定してください` })
+    .min(1, { error: `${label} は 1 以上で指定してください` });
+
+/**
+ * 評価項目の単体作成 body。所属（targetId・categoryId）と name が必須。
+ * no・index は lib（`createEvaluationItem`）が自動採番する。
+ * 所属の存在・categoryId と targetId の整合は lib が検証する（404 / 400）。
+ */
+export const evaluationItemCreateBodySchema = z.object(
+  {
+    targetId: positiveIntField("targetId"),
+    categoryId: positiveIntField("categoryId"),
+    name: nameField,
+    description: z.string().nullish(),
+    evalCriteria: z.string().nullish(),
+  },
+  { error: "リクエストボディが不正です" },
+);
+
+/**
+ * 評価項目の更新 body（すべて任意）。空 body は lib（`updateEvaluationItem`）が
+ * BadRequest→400 を返す。
+ */
+export const evaluationItemUpdateBodySchema = z.object(
+  {
+    name: nameField.optional(),
+    no: positiveIntField("no").optional(),
+    description: z.string().nullish(),
+    evalCriteria: z.string().nullish(),
+  },
+  { error: "リクエストボディが不正です" },
+);

--- a/src/lib/schemas/evaluation-item.ts
+++ b/src/lib/schemas/evaluation-item.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { nameField, positiveIntField } from "@/lib/schemas/common";
 
 /**
  * 評価項目一括インポート（POST /api/evaluation-items/import）の body スキーマ。
@@ -57,17 +58,6 @@ export const evaluationItemResponseSchema = z.object({
 export const evaluationItemListResponseSchema = z.object({
   evaluationItems: z.array(evaluationItemResponseSchema),
 });
-
-/** 非空の名称フィールド（空文字・空白のみを弾く）。 */
-const nameField = z
-  .string({ error: "name は必須です" })
-  .refine((v) => v.trim().length > 0, { error: "name は必須です" });
-
-const positiveIntField = (label: string) =>
-  z
-    .number({ error: `${label} は数値で指定してください` })
-    .int({ error: `${label} は整数で指定してください` })
-    .min(1, { error: `${label} は 1 以上で指定してください` });
 
 /**
  * 評価項目の単体作成 body。所属（targetId・categoryId）と name が必須。

--- a/src/lib/schemas/target.ts
+++ b/src/lib/schemas/target.ts
@@ -1,15 +1,5 @@
 import { z } from "zod";
-
-/** 非空の名称フィールド（空文字・空白のみを弾く）。 */
-const nameField = z
-  .string({ error: "name は必須です" })
-  .refine((v) => v.trim().length > 0, { error: "name は必須です" });
-
-/** 管理番号フィールド（1 以上の整数）。 */
-const noField = z
-  .number({ error: "no は数値で指定してください" })
-  .int({ error: "no は整数で指定してください" })
-  .min(1, { error: "no は 1 以上で指定してください" });
+import { nameField, positiveIntField } from "@/lib/schemas/common";
 
 /**
  * 大分類の作成 body。no・index は lib（`createTarget`）が自動採番する。
@@ -24,7 +14,7 @@ export const targetUpdateBodySchema = z
   .object(
     {
       name: nameField.optional(),
-      no: noField.optional(),
+      no: positiveIntField("no").optional(),
     },
     { error: "リクエストボディが不正です" },
   )


### PR DESCRIPTION
## Summary

外部 REST API 化 epic（#13 / まとめブランチ `feature/rest-api`）の第3フェーズ。T211 で新契約化した evaluation-items を、targets/categories と同じく単体 CRUD + reorder に拡充する。

### エンドポイント（すべて ADMIN）

| メソッド | パス | 変更 |
|---------|------|------|
| GET | `/api/evaluation-items?targetId=&categoryId=` | クエリ絞り込みを追加 |
| POST | `/api/evaluation-items` | **一括インポート → 単体作成（201）** |
| POST | `/api/evaluation-items/import` | 一括インポートを**移設** |
| PATCH | `/api/evaluation-items/{id}` | 新規（更新） |
| DELETE | `/api/evaluation-items/{id}` | 新規（204） |
| POST | `/api/evaluation-items/reorder` | 新規（204） |

### 実装

- **Zod**: `evaluationItemCreateBodySchema`（targetId/categoryId≥1・name 非空・description/evalCriteria nullish）、`evaluationItemUpdateBodySchema`（name 非空・no≥1・任意）。空更新は lib（`updateEvaluationItem`）が BadRequest→400
- **lib 委譲**: 既存 `createEvaluationItem`/`updateEvaluationItem`/`deleteEvaluationItem`/`reorderEvaluationItems`/`bulkReplaceEvaluationItems`
- **OpenAPI**: evaluation-items を 4 パス（GET/POST・import・{id}・reorder）/ 全 16 オペレーションに再構成。`{id}` は integer path param

### 破壊的変更（epic 内）

- `POST /api/evaluation-items` の意味を「一括インポート」→「単体作成」に変更、一括は `/import` へ移設。base は `feature/rest-api` のため develop への影響は後段まで発生しない。

## Test plan

- [x] ユニットテスト 339 passed（各ルート 200/201/204/400/401/403/404/409）
- [x] `next build` で 4 ルート登録確認
- [x] 実 API キーで読み取り検証（401 / 200・122件 / targetId 21件 / categoryId 10件 / 不正クエリ 400 / MEMBER 403） — [結果コメント](https://github.com/ot-nemoto/eval-hub/issues/389#issuecomment-4979243876)
- [x] `/api-reference` に evaluation-items の6オペレーション表示を確認

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)