### PR TITLE
[T214] fiscal-years の REST API（CRUD + ロック）

### DIFF
--- a/src/app/api/fiscal-years/[year]/lock/route.test.ts
+++ b/src/app/api/fiscal-years/[year]/lock/route.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/fiscal-years", () => ({ toggleFiscalYearLock: vi.fn() }));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { NotFoundError } from "@/lib/errors";
+import { toggleFiscalYearLock } from "@/lib/fiscal-years";
+import { POST } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+
+const lockedFy = {
+  year: 2025,
+  name: "2025年度",
+  startDate: new Date("2025-04-01"),
+  endDate: new Date("2026-03-31"),
+  isCurrent: false,
+  isLocked: true,
+  evalItemVersionId: null,
+};
+
+function makeRequest(body?: unknown) {
+  return new Request("http://localhost/api/fiscal-years/2025/lock", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", authorization: "Bearer key" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  }) as import("next/server").NextRequest;
+}
+
+const ctx = (year = "2025") => ({ params: Promise.resolve({ year }) });
+
+describe("POST /api/fiscal-years/[year]/lock", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("ロックして 200 と更新後の年度を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(toggleFiscalYearLock).mockResolvedValue(lockedFy as never);
+
+    const res = await POST(makeRequest({ isLocked: true }), ctx());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.isLocked).toBe(true);
+    expect(toggleFiscalYearLock).toHaveBeenCalledWith(2025, true);
+  });
+
+  it("isLocked 欠落・非真偽値は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makeRequest({}), ctx())).status).toBe(400);
+    expect((await POST(makeRequest({ isLocked: "yes" }), ctx())).status).toBe(400);
+    expect(toggleFiscalYearLock).not.toHaveBeenCalled();
+  });
+
+  it("未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(toggleFiscalYearLock).mockRejectedValue(new NotFoundError("年度が見つかりません"));
+    expect((await POST(makeRequest({ isLocked: true }), ctx())).status).toBe(404);
+  });
+
+  it("year 不正は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makeRequest({ isLocked: true }), ctx("abc"))).status).toBe(400);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await POST(makeRequest({ isLocked: true }), ctx())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await POST(makeRequest({ isLocked: true }), ctx())).status).toBe(403);
+  });
+});

--- a/src/app/api/fiscal-years/[year]/lock/route.ts
+++ b/src/app/api/fiscal-years/[year]/lock/route.ts
@@ -1,0 +1,39 @@
+import { type NextRequest, NextResponse } from "next/server";
+import {
+  jsonError,
+  jsonErrorFromException,
+  serializeFiscalYear,
+  unauthorized,
+} from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { toggleFiscalYearLock } from "@/lib/fiscal-years";
+import { firstZodError } from "@/lib/schemas/_zod-error";
+import { fiscalYearLockBodySchema } from "@/lib/schemas/fiscal-year";
+
+type RouteContext = { params: Promise<{ year: string }> };
+
+function parseYear(year: string): number | null {
+  const n = Number(year);
+  return Number.isInteger(n) ? n : null;
+}
+
+export async function POST(req: NextRequest, { params }: RouteContext) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const { year } = await params;
+  const y = parseYear(year);
+  if (y === null) return jsonError("year は整数で指定してください", 400);
+
+  const body = await req.json().catch(() => null);
+  const parsed = fiscalYearLockBodySchema.safeParse(body);
+  if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
+
+  try {
+    const fy = await toggleFiscalYearLock(y, parsed.data.isLocked);
+    return NextResponse.json(serializeFiscalYear(fy));
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/app/api/fiscal-years/[year]/route.test.ts
+++ b/src/app/api/fiscal-years/[year]/route.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/fiscal-years", () => ({ updateFiscalYear: vi.fn(), deleteFiscalYear: vi.fn() }));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { BadRequestError, ConflictError, NotFoundError } from "@/lib/errors";
+import { deleteFiscalYear, updateFiscalYear } from "@/lib/fiscal-years";
+import { DELETE, PATCH } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+
+const libFy = {
+  year: 2025,
+  name: "2025年度(更新)",
+  startDate: new Date("2025-04-01"),
+  endDate: new Date("2026-03-31"),
+  isCurrent: true,
+  isLocked: false,
+  evalItemVersionId: null,
+};
+
+function makeRequest(method: string, body?: unknown) {
+  return new Request("http://localhost/api/fiscal-years/2025", {
+    method,
+    headers: { "Content-Type": "application/json", authorization: "Bearer key" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  }) as import("next/server").NextRequest;
+}
+
+const ctx = (year = "2025") => ({ params: Promise.resolve({ year }) });
+
+describe("PATCH /api/fiscal-years/[year]", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("更新して 200 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(updateFiscalYear).mockResolvedValue(libFy as never);
+
+    const res = await PATCH(
+      makeRequest("PATCH", { name: "2025年度(更新)", isCurrent: true }),
+      ctx(),
+    );
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.name).toBe("2025年度(更新)");
+    expect(updateFiscalYear).toHaveBeenCalledWith(2025, {
+      name: "2025年度(更新)",
+      isCurrent: true,
+    });
+  });
+
+  it("空 body は 400（lib が BadRequest）", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(updateFiscalYear).mockRejectedValue(
+      new BadRequestError("更新するフィールドを指定してください"),
+    );
+    expect((await PATCH(makeRequest("PATCH", {}), ctx())).status).toBe(400);
+  });
+
+  it("未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(updateFiscalYear).mockRejectedValue(new NotFoundError("年度が見つかりません"));
+    expect((await PATCH(makeRequest("PATCH", { name: "x" }), ctx())).status).toBe(404);
+  });
+
+  it("isCurrent 非真偽値は 400（Zod）", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await PATCH(makeRequest("PATCH", { isCurrent: "yes" }), ctx())).status).toBe(400);
+    expect(updateFiscalYear).not.toHaveBeenCalled();
+  });
+
+  it("year 不正は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await PATCH(makeRequest("PATCH", { name: "x" }), ctx("abc"))).status).toBe(400);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await PATCH(makeRequest("PATCH", { name: "x" }), ctx())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await PATCH(makeRequest("PATCH", { name: "x" }), ctx())).status).toBe(403);
+  });
+});
+
+describe("DELETE /api/fiscal-years/[year]", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("削除して 204 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(deleteFiscalYear).mockResolvedValue(undefined);
+
+    const res = await DELETE(makeRequest("DELETE"), ctx());
+    expect(res.status).toBe(204);
+    expect(deleteFiscalYear).toHaveBeenCalledWith(2025);
+  });
+
+  it("紐づくデータあり（ConflictError）は 409", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(deleteFiscalYear).mockRejectedValue(
+      new ConflictError("紐づくデータが存在するため削除できません"),
+    );
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(409);
+  });
+
+  it("未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(deleteFiscalYear).mockRejectedValue(new NotFoundError("年度が見つかりません"));
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(404);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(403);
+  });
+});

--- a/src/app/api/fiscal-years/[year]/route.ts
+++ b/src/app/api/fiscal-years/[year]/route.ts
@@ -1,0 +1,56 @@
+import { type NextRequest, NextResponse } from "next/server";
+import {
+  jsonError,
+  jsonErrorFromException,
+  serializeFiscalYear,
+  unauthorized,
+} from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { deleteFiscalYear, updateFiscalYear } from "@/lib/fiscal-years";
+import { firstZodError } from "@/lib/schemas/_zod-error";
+import { fiscalYearUpdateBodySchema } from "@/lib/schemas/fiscal-year";
+
+type RouteContext = { params: Promise<{ year: string }> };
+
+function parseYear(year: string): number | null {
+  const n = Number(year);
+  return Number.isInteger(n) ? n : null;
+}
+
+export async function PATCH(req: NextRequest, { params }: RouteContext) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const { year } = await params;
+  const y = parseYear(year);
+  if (y === null) return jsonError("year は整数で指定してください", 400);
+
+  const body = await req.json().catch(() => null);
+  const parsed = fiscalYearUpdateBodySchema.safeParse(body);
+  if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
+
+  try {
+    const fy = await updateFiscalYear(y, parsed.data);
+    return NextResponse.json(serializeFiscalYear(fy));
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: RouteContext) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const { year } = await params;
+  const y = parseYear(year);
+  if (y === null) return jsonError("year は整数で指定してください", 400);
+
+  try {
+    await deleteFiscalYear(y);
+    return new NextResponse(null, { status: 204 });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/app/api/fiscal-years/route.test.ts
+++ b/src/app/api/fiscal-years/route.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/fiscal-years", () => ({ getFiscalYears: vi.fn(), createFiscalYear: vi.fn() }));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { BadRequestError, ConflictError } from "@/lib/errors";
+import { createFiscalYear, getFiscalYears } from "@/lib/fiscal-years";
+import { GET, POST } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+
+const libFy = {
+  year: 2025,
+  name: "2025年度",
+  startDate: new Date("2025-04-01"),
+  endDate: new Date("2026-03-31"),
+  isCurrent: true,
+  isLocked: false,
+  evalItemVersionId: null,
+};
+const serialized = {
+  year: 2025,
+  name: "2025年度",
+  startDate: "2025-04-01",
+  endDate: "2026-03-31",
+  isCurrent: true,
+  isLocked: false,
+  evalItemVersionId: null,
+};
+
+function makeGet() {
+  return new Request("http://localhost/api/fiscal-years", {
+    method: "GET",
+    headers: { authorization: "Bearer key" },
+  }) as import("next/server").NextRequest;
+}
+function makePost(body: unknown) {
+  return new Request("http://localhost/api/fiscal-years", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", authorization: "Bearer key" },
+    body: JSON.stringify(body),
+  }) as import("next/server").NextRequest;
+}
+
+const validBody = {
+  year: 2025,
+  name: "2025年度",
+  startDate: "2025-04-01",
+  endDate: "2026-03-31",
+};
+
+describe("GET /api/fiscal-years", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("ADMIN は一覧を返す（日付は YYYY-MM-DD）", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(getFiscalYears).mockResolvedValue([libFy] as never);
+
+    const res = await GET(makeGet());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ fiscalYears: [serialized] });
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await GET(makeGet())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await GET(makeGet())).status).toBe(403);
+  });
+});
+
+describe("POST /api/fiscal-years", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("作成して 201 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(createFiscalYear).mockResolvedValue(libFy as never);
+
+    const res = await POST(makePost(validBody));
+    const body = await res.json();
+    expect(res.status).toBe(201);
+    expect(body).toEqual(serialized);
+    expect(createFiscalYear).toHaveBeenCalledWith(validBody);
+  });
+
+  it("year 範囲外は 400（Zod）", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makePost({ ...validBody, year: 1800 }))).status).toBe(400);
+    expect(createFiscalYear).not.toHaveBeenCalled();
+  });
+
+  it("name 空・必須欠落は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makePost({ ...validBody, name: "" }))).status).toBe(400);
+    expect((await POST(makePost({ year: 2025, name: "x" }))).status).toBe(400);
+  });
+
+  it("日付不正（lib）は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(createFiscalYear).mockRejectedValue(
+      new BadRequestError("startDate は endDate 以前の日付を指定してください"),
+    );
+    expect((await POST(makePost(validBody))).status).toBe(400);
+  });
+
+  it("年度重複は 409", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(createFiscalYear).mockRejectedValue(new ConflictError("同じ年度がすでに存在します"));
+    expect((await POST(makePost(validBody))).status).toBe(409);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await POST(makePost(validBody))).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await POST(makePost(validBody))).status).toBe(403);
+  });
+});

--- a/src/app/api/fiscal-years/route.test.ts
+++ b/src/app/api/fiscal-years/route.test.ts
@@ -99,6 +99,13 @@ describe("POST /api/fiscal-years", () => {
     expect((await POST(makePost({ year: 2025, name: "x" }))).status).toBe(400);
   });
 
+  it("非 ISO 日付（YYYY/MM/DD 等）は 400（Zod）", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makePost({ ...validBody, startDate: "2025/04/01" }))).status).toBe(400);
+    expect((await POST(makePost({ ...validBody, endDate: "April 1, 2026" }))).status).toBe(400);
+    expect(createFiscalYear).not.toHaveBeenCalled();
+  });
+
   it("日付不正（lib）は 400", async () => {
     vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
     vi.mocked(createFiscalYear).mockRejectedValue(

--- a/src/app/api/fiscal-years/route.ts
+++ b/src/app/api/fiscal-years/route.ts
@@ -1,0 +1,41 @@
+import { type NextRequest, NextResponse } from "next/server";
+import {
+  jsonError,
+  jsonErrorFromException,
+  serializeFiscalYear,
+  unauthorized,
+} from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { createFiscalYear, getFiscalYears } from "@/lib/fiscal-years";
+import { firstZodError } from "@/lib/schemas/_zod-error";
+import { fiscalYearCreateBodySchema } from "@/lib/schemas/fiscal-year";
+
+export async function GET(req: NextRequest) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  try {
+    const fiscalYears = await getFiscalYears();
+    return NextResponse.json({ fiscalYears: fiscalYears.map(serializeFiscalYear) });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const body = await req.json().catch(() => null);
+  const parsed = fiscalYearCreateBodySchema.safeParse(body);
+  if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
+
+  try {
+    const fy = await createFiscalYear(parsed.data);
+    return NextResponse.json(serializeFiscalYear(fy), { status: 201 });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -76,3 +76,26 @@ type SerializableCategory = {
 export function serializeCategory(c: SerializableCategory) {
   return { id: c.id, targetId: c.targetId, name: c.name, no: c.no, index: c.index };
 }
+
+type SerializableFiscalYear = {
+  year: number;
+  name: string;
+  startDate: Date;
+  endDate: Date;
+  isCurrent: boolean;
+  isLocked: boolean;
+  evalItemVersionId: number | null;
+};
+
+/** 年度を外部 API レスポンス形式（日付は YYYY-MM-DD）に整形する。 */
+export function serializeFiscalYear(fy: SerializableFiscalYear) {
+  return {
+    year: fy.year,
+    name: fy.name,
+    startDate: fy.startDate.toISOString().slice(0, 10),
+    endDate: fy.endDate.toISOString().slice(0, 10),
+    isCurrent: fy.isCurrent,
+    isLocked: fy.isLocked,
+    evalItemVersionId: fy.evalItemVersionId,
+  };
+}

--- a/src/lib/openapi/document.test.ts
+++ b/src/lib/openapi/document.test.ts
@@ -15,6 +15,9 @@ const EXPECTED_PATHS = [
   "/api/categories",
   "/api/categories/reorder",
   "/api/categories/{id}",
+  "/api/fiscal-years",
+  "/api/fiscal-years/{year}",
+  "/api/fiscal-years/{year}/lock",
 ];
 
 const HTTP_METHODS = ["get", "post", "patch", "put", "delete"];
@@ -62,7 +65,7 @@ describe("buildOpenApiDocument", () => {
       (n, item) => n + Object.keys(item).filter((k) => HTTP_METHODS.includes(k)).length,
       0,
     );
-    expect(opCount).toBe(16);
+    expect(opCount).toBe(21);
   });
 
   it("各オペレーションに summary と responses がある", () => {
@@ -98,6 +101,11 @@ describe("buildOpenApiDocument", () => {
         "CategoryList",
         "CategoryCreate",
         "CategoryUpdate",
+        "FiscalYear",
+        "FiscalYearList",
+        "FiscalYearCreate",
+        "FiscalYearUpdate",
+        "FiscalYearLock",
       ]),
     );
   });

--- a/src/lib/openapi/document.ts
+++ b/src/lib/openapi/document.ts
@@ -15,6 +15,13 @@ import {
   evaluationItemUpdateBodySchema,
 } from "@/lib/schemas/evaluation-item";
 import {
+  fiscalYearCreateBodySchema,
+  fiscalYearListResponseSchema,
+  fiscalYearLockBodySchema,
+  fiscalYearResponseSchema,
+  fiscalYearUpdateBodySchema,
+} from "@/lib/schemas/fiscal-year";
+import {
   targetCreateBodySchema,
   targetListResponseSchema,
   targetResponseSchema,
@@ -122,6 +129,15 @@ const idParam = {
   description: "対象リソースの ID",
 };
 
+/** 年度（PK）の path パラメータ定義。 */
+const yearParam = {
+  name: "year",
+  in: "path",
+  required: true,
+  schema: { type: "integer" },
+  description: "対象年度（例: 2025）",
+};
+
 /** OpenAPI 3.1 ドキュメントを組み立てる。`serverUrl`（アクセス元オリジン）があれば servers 先頭に置く。 */
 export function buildOpenApiDocument(options: { version?: string; serverUrl?: string } = {}) {
   const localhost = "http://localhost:3000";
@@ -167,6 +183,11 @@ export function buildOpenApiDocument(options: { version?: string; serverUrl?: st
         CategoryList: toSchema(categoryListResponseSchema),
         CategoryCreate: toSchema(categoryCreateBodySchema),
         CategoryUpdate: toSchema(categoryUpdateBodySchema),
+        FiscalYear: toSchema(fiscalYearResponseSchema),
+        FiscalYearList: toSchema(fiscalYearListResponseSchema),
+        FiscalYearCreate: toSchema(fiscalYearCreateBodySchema),
+        FiscalYearUpdate: toSchema(fiscalYearUpdateBodySchema),
+        FiscalYearLock: toSchema(fiscalYearLockBodySchema),
       },
     },
     paths: {
@@ -407,6 +428,72 @@ export function buildOpenApiDocument(options: { version?: string; serverUrl?: st
             403: errorResponse("ADMIN 権限が必要"),
             404: errorResponse("未存在"),
             409: errorResponse("紐づく評価項目が存在"),
+          },
+        },
+      },
+      "/api/fiscal-years": {
+        get: {
+          summary: "年度一覧を取得",
+          tags: ["fiscal-years"],
+          responses: {
+            200: jsonResponse("年度の一覧", ref("FiscalYearList")),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+          },
+        },
+        post: {
+          summary: "年度を作成",
+          tags: ["fiscal-years"],
+          requestBody: jsonBody("FiscalYearCreate"),
+          responses: {
+            201: jsonResponse("作成された年度", ref("FiscalYear")),
+            400: errorResponse("バリデーションエラー（year 範囲・日付・期間前後）"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            409: errorResponse("同じ年度が既に存在"),
+          },
+        },
+      },
+      "/api/fiscal-years/{year}": {
+        patch: {
+          summary: "年度を更新（名称・期間・現在年度フラグ）",
+          tags: ["fiscal-years"],
+          parameters: [yearParam],
+          requestBody: jsonBody("FiscalYearUpdate"),
+          responses: {
+            200: jsonResponse("更新後の年度", ref("FiscalYear")),
+            400: errorResponse("バリデーションエラー / 更新フィールドなし"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("未存在"),
+          },
+        },
+        delete: {
+          summary: "年度を削除",
+          tags: ["fiscal-years"],
+          parameters: [yearParam],
+          responses: {
+            204: { description: "削除成功（ボディなし）" },
+            400: errorResponse("year 不正"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("未存在"),
+            409: errorResponse("紐づくデータが存在"),
+          },
+        },
+      },
+      "/api/fiscal-years/{year}/lock": {
+        post: {
+          summary: "年度のロック状態を設定",
+          tags: ["fiscal-years"],
+          parameters: [yearParam],
+          requestBody: jsonBody("FiscalYearLock"),
+          responses: {
+            200: jsonResponse("更新後の年度", ref("FiscalYear")),
+            400: errorResponse("バリデーションエラー / year 不正"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("未存在"),
           },
         },
       },

--- a/src/lib/schemas/fiscal-year.ts
+++ b/src/lib/schemas/fiscal-year.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import { nameField } from "@/lib/schemas/common";
+
+const yearField = z
+  .number({
+    error: (iss) => (iss.input === undefined ? "year は必須です" : "year は数値で指定してください"),
+  })
+  .int({ error: "year は整数で指定してください" })
+  .min(1900, { error: "year は 1900〜9999 で指定してください" })
+  .max(9999, { error: "year は 1900〜9999 で指定してください" });
+
+const dateField = (label: string) => z.string({ error: `${label} は必須です` });
+
+/**
+ * 年度の作成 body。日付の妥当性・startDate≤endDate・year 重複(409) は
+ * lib（`createFiscalYear`）が担保する。
+ */
+export const fiscalYearCreateBodySchema = z.object(
+  {
+    year: yearField,
+    name: nameField,
+    startDate: dateField("startDate"),
+    endDate: dateField("endDate"),
+  },
+  { error: "リクエストボディが不正です" },
+);
+
+/**
+ * 年度の更新 body（すべて任意）。空 body は lib（`updateFiscalYear`）が
+ * BadRequest→400 を返す。
+ */
+export const fiscalYearUpdateBodySchema = z.object(
+  {
+    name: nameField.optional(),
+    startDate: z.string().optional(),
+    endDate: z.string().optional(),
+    isCurrent: z.boolean({ error: "isCurrent は真偽値で指定してください" }).optional(),
+  },
+  { error: "リクエストボディが不正です" },
+);
+
+/** 年度のロック状態設定 body。 */
+export const fiscalYearLockBodySchema = z.object(
+  { isLocked: z.boolean({ error: "isLocked は真偽値で指定してください" }) },
+  { error: "リクエストボディが不正です" },
+);
+
+/** 年度のレスポンス形式。 */
+export const fiscalYearResponseSchema = z.object({
+  year: z.number().int(),
+  name: z.string(),
+  startDate: z.string(),
+  endDate: z.string(),
+  isCurrent: z.boolean(),
+  isLocked: z.boolean(),
+  evalItemVersionId: z.number().int().nullable(),
+});
+
+/** GET /api/fiscal-years のレスポンス（一覧ラッパ）。 */
+export const fiscalYearListResponseSchema = z.object({
+  fiscalYears: z.array(fiscalYearResponseSchema),
+});

--- a/src/lib/schemas/fiscal-year.ts
+++ b/src/lib/schemas/fiscal-year.ts
@@ -9,7 +9,8 @@ const yearField = z
   .min(1900, { error: "year は 1900〜9999 で指定してください" })
   .max(9999, { error: "year は 1900〜9999 で指定してください" });
 
-const dateField = (label: string) => z.string({ error: `${label} は必須です` });
+const dateField = (label: string) =>
+  z.iso.date({ error: `${label} は YYYY-MM-DD 形式で指定してください` });
 
 /**
  * 年度の作成 body。日付の妥当性・startDate≤endDate・year 重複(409) は
@@ -32,8 +33,8 @@ export const fiscalYearCreateBodySchema = z.object(
 export const fiscalYearUpdateBodySchema = z.object(
   {
     name: nameField.optional(),
-    startDate: z.string().optional(),
-    endDate: z.string().optional(),
+    startDate: dateField("startDate").optional(),
+    endDate: dateField("endDate").optional(),
     isCurrent: z.boolean({ error: "isCurrent は真偽値で指定してください" }).optional(),
   },
   { error: "リクエストボディが不正です" },


### PR DESCRIPTION
## Summary

外部 REST API 化 epic（#13 / まとめブランチ `feature/rest-api`）の第4フェーズ。年度マスタ（fiscal_years、PK=`year`）を REST API 化する。T211〜213 の契約を踏襲。

### エンドポイント（すべて ADMIN）

| メソッド | パス | 説明 |
|---------|------|------|
| GET | `/api/fiscal-years` | 一覧取得 |
| POST | `/api/fiscal-years` | 作成（201） |
| PATCH | `/api/fiscal-years/{year}` | 名称・期間・現在年度フラグ更新 |
| DELETE | `/api/fiscal-years/{year}` | 削除（204・紐づきデータありは 409） |
| POST | `/api/fiscal-years/{year}/lock` | ロック状態設定（`{ isLocked }` → 200） |

### 実装

- **Zod**: `schemas/fiscal-year.ts`（create: year 1900-9999・name 非空・startDate/endDate、update: 任意・空は lib が 400、lock: `{ isLocked: boolean }`）。日付妥当性・期間前後・year 重複(409) は lib（`createFiscalYear`/`updateFiscalYear`）が担保
- **lib 委譲**: `getFiscalYears`/`createFiscalYear`/`updateFiscalYear`/`toggleFiscalYearLock`/`deleteFiscalYear`
- **serialize**: `startDate`/`endDate`（`@db.Date`）を `YYYY-MM-DD` に整形、`evalItemVersionId` は nullable
- **OpenAPI**: fiscal-years の paths・schemas を追記（全 21 オペレーション）。`{year}` は integer path param

## Test plan

- [x] ユニットテスト 362 passed（各ルート 200/201/204/400/401/403/404/409）
- [x] `next build` で 3 ルート登録確認
- [x] 実 API キーで読み取り検証（キーなし 401 / ADMIN 200・5件・日付 YYYY-MM-DD 整形 / MEMBER 403） — [結果コメント](https://github.com/ot-nemoto/eval-hub/issues/391#issuecomment-4979555022)
- [x] `/api-reference` に fiscal-years の5オペレーション表示を確認

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)