### PR TITLE
[T215] evaluation-assignments / evaluation-settings の REST API

### DIFF
--- a/src/app/api/evaluation-assignments/[id]/route.test.ts
+++ b/src/app/api/evaluation-assignments/[id]/route.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/evaluation-assignments", () => ({ deleteEvaluationAssignment: vi.fn() }));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { NotFoundError } from "@/lib/errors";
+import { deleteEvaluationAssignment } from "@/lib/evaluation-assignments";
+import { DELETE } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+
+function makeRequest() {
+  return new Request("http://localhost/api/evaluation-assignments/a1", {
+    method: "DELETE",
+    headers: { authorization: "Bearer key" },
+  }) as import("next/server").NextRequest;
+}
+
+const ctx = (id = "a1") => ({ params: Promise.resolve({ id }) });
+
+describe("DELETE /api/evaluation-assignments/[id]", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("削除して 204 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(deleteEvaluationAssignment).mockResolvedValue(undefined);
+
+    const res = await DELETE(makeRequest(), ctx());
+    expect(res.status).toBe(204);
+    expect(deleteEvaluationAssignment).toHaveBeenCalledWith("a1");
+  });
+
+  it("未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(deleteEvaluationAssignment).mockRejectedValue(
+      new NotFoundError("アサインが見つかりません"),
+    );
+    expect((await DELETE(makeRequest(), ctx())).status).toBe(404);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await DELETE(makeRequest(), ctx())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await DELETE(makeRequest(), ctx())).status).toBe(403);
+  });
+});

--- a/src/app/api/evaluation-assignments/[id]/route.ts
+++ b/src/app/api/evaluation-assignments/[id]/route.ts
@@ -1,0 +1,21 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { jsonError, jsonErrorFromException, unauthorized } from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { deleteEvaluationAssignment } from "@/lib/evaluation-assignments";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function DELETE(req: NextRequest, { params }: RouteContext) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const { id } = await params;
+
+  try {
+    await deleteEvaluationAssignment(id);
+    return new NextResponse(null, { status: 204 });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/app/api/evaluation-assignments/route.test.ts
+++ b/src/app/api/evaluation-assignments/route.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/evaluation-assignments", () => ({
+  getEvaluationAssignments: vi.fn(),
+  createEvaluationAssignment: vi.fn(),
+}));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { ConflictError } from "@/lib/errors";
+import { createEvaluationAssignment, getEvaluationAssignments } from "@/lib/evaluation-assignments";
+import { GET, POST } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+
+const listItem = {
+  id: "a1",
+  fiscalYear: 2025,
+  evaluatee: { id: "e1", name: "被評価者" },
+  evaluator: { id: "r1", name: "評価者" },
+};
+const created = { id: "a1", fiscalYear: 2025, evaluateeId: "e1", evaluatorId: "r1" };
+
+function makeGet(query = "") {
+  return new Request(`http://localhost/api/evaluation-assignments${query}`, {
+    method: "GET",
+    headers: { authorization: "Bearer key" },
+  }) as import("next/server").NextRequest;
+}
+function makePost(body: unknown) {
+  return new Request("http://localhost/api/evaluation-assignments", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", authorization: "Bearer key" },
+    body: JSON.stringify(body),
+  }) as import("next/server").NextRequest;
+}
+
+describe("GET /api/evaluation-assignments", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("ADMIN は一覧を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(getEvaluationAssignments).mockResolvedValue([listItem]);
+
+    const res = await GET(makeGet());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ evaluationAssignments: [listItem] });
+    expect(getEvaluationAssignments).toHaveBeenCalledWith({
+      fiscalYear: undefined,
+      evaluateeId: undefined,
+    });
+  });
+
+  it("fiscalYear・evaluateeId で絞り込む", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(getEvaluationAssignments).mockResolvedValue([]);
+
+    await GET(makeGet("?fiscalYear=2025&evaluateeId=e1"));
+    expect(getEvaluationAssignments).toHaveBeenCalledWith({ fiscalYear: 2025, evaluateeId: "e1" });
+  });
+
+  it("fiscalYear 不正は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await GET(makeGet("?fiscalYear=abc"))).status).toBe(400);
+    expect(getEvaluationAssignments).not.toHaveBeenCalled();
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await GET(makeGet())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await GET(makeGet())).status).toBe(403);
+  });
+});
+
+describe("POST /api/evaluation-assignments", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const validBody = { fiscalYear: 2025, evaluateeId: "e1", evaluatorId: "r1" };
+
+  it("作成して 201（flat）を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(createEvaluationAssignment).mockResolvedValue(created as never);
+
+    const res = await POST(makePost(validBody));
+    const body = await res.json();
+    expect(res.status).toBe(201);
+    expect(body).toEqual(created);
+    expect(createEvaluationAssignment).toHaveBeenCalledWith(validBody);
+  });
+
+  it("必須欠落・年度範囲外は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makePost({ fiscalYear: 2025, evaluateeId: "e1" }))).status).toBe(400);
+    expect((await POST(makePost({ ...validBody, fiscalYear: 1800 }))).status).toBe(400);
+    expect((await POST(makePost({ ...validBody, evaluateeId: "" }))).status).toBe(400);
+    expect(createEvaluationAssignment).not.toHaveBeenCalled();
+  });
+
+  it("重複は 409", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(createEvaluationAssignment).mockRejectedValue(
+      new ConflictError("同一年度・被評価者・評価者の組み合わせがすでに存在します"),
+    );
+    expect((await POST(makePost(validBody))).status).toBe(409);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await POST(makePost(validBody))).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await POST(makePost(validBody))).status).toBe(403);
+  });
+});

--- a/src/app/api/evaluation-assignments/route.test.ts
+++ b/src/app/api/evaluation-assignments/route.test.ts
@@ -8,7 +8,7 @@ vi.mock("@/lib/evaluation-assignments", () => ({
 }));
 
 import { getAuthenticatedUser } from "@/lib/apiAuth";
-import { ConflictError } from "@/lib/errors";
+import { ConflictError, NotFoundError } from "@/lib/errors";
 import { createEvaluationAssignment, getEvaluationAssignments } from "@/lib/evaluation-assignments";
 import { GET, POST } from "./route";
 
@@ -98,6 +98,14 @@ describe("POST /api/evaluation-assignments", () => {
     expect((await POST(makePost({ ...validBody, fiscalYear: 1800 }))).status).toBe(400);
     expect((await POST(makePost({ ...validBody, evaluateeId: "" }))).status).toBe(400);
     expect(createEvaluationAssignment).not.toHaveBeenCalled();
+  });
+
+  it("存在しないユーザー（NotFoundError）は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(createEvaluationAssignment).mockRejectedValue(
+      new NotFoundError("被評価者が見つかりません"),
+    );
+    expect((await POST(makePost(validBody))).status).toBe(404);
   });
 
   it("重複は 409", async () => {

--- a/src/app/api/evaluation-assignments/route.ts
+++ b/src/app/api/evaluation-assignments/route.ts
@@ -1,0 +1,46 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { jsonError, jsonErrorFromException, unauthorized } from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { createEvaluationAssignment, getEvaluationAssignments } from "@/lib/evaluation-assignments";
+import { firstZodError } from "@/lib/schemas/_zod-error";
+import { evaluationAssignmentCreateBodySchema } from "@/lib/schemas/evaluation-assignment";
+
+export async function GET(req: NextRequest) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const params = new URL(req.url).searchParams;
+  const fiscalYearParam = params.get("fiscalYear");
+  let fiscalYear: number | undefined;
+  if (fiscalYearParam !== null) {
+    const n = Number(fiscalYearParam);
+    if (!Number.isInteger(n)) return jsonError("fiscalYear は整数で指定してください", 400);
+    fiscalYear = n;
+  }
+  const evaluateeId = params.get("evaluateeId") ?? undefined;
+
+  try {
+    const evaluationAssignments = await getEvaluationAssignments({ fiscalYear, evaluateeId });
+    return NextResponse.json({ evaluationAssignments });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const body = await req.json().catch(() => null);
+  const parsed = evaluationAssignmentCreateBodySchema.safeParse(body);
+  if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
+
+  try {
+    const assignment = await createEvaluationAssignment(parsed.data);
+    return NextResponse.json(assignment, { status: 201 });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/app/api/evaluation-settings/route.test.ts
+++ b/src/app/api/evaluation-settings/route.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/evaluation-settings", () => ({
+  getEvaluationSettings: vi.fn(),
+  upsertEvaluationSetting: vi.fn(),
+}));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { NotFoundError } from "@/lib/errors";
+import { getEvaluationSettings, upsertEvaluationSetting } from "@/lib/evaluation-settings";
+import { GET, POST } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+
+const setting = { fiscalYear: 2025, selfEvaluationEnabled: true };
+
+function makeGet(query = "") {
+  return new Request(`http://localhost/api/evaluation-settings${query}`, {
+    method: "GET",
+    headers: { authorization: "Bearer key" },
+  }) as import("next/server").NextRequest;
+}
+function makePost(body: unknown) {
+  return new Request("http://localhost/api/evaluation-settings", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", authorization: "Bearer key" },
+    body: JSON.stringify(body),
+  }) as import("next/server").NextRequest;
+}
+
+describe("GET /api/evaluation-settings", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("userId 指定で一覧を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(getEvaluationSettings).mockResolvedValue([setting]);
+
+    const res = await GET(makeGet("?userId=u9"));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ evaluationSettings: [setting] });
+    expect(getEvaluationSettings).toHaveBeenCalledWith("u9");
+  });
+
+  it("userId 未指定は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await GET(makeGet())).status).toBe(400);
+    expect(getEvaluationSettings).not.toHaveBeenCalled();
+  });
+
+  it("ユーザー未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(getEvaluationSettings).mockRejectedValue(
+      new NotFoundError("ユーザーが見つかりません"),
+    );
+    expect((await GET(makeGet("?userId=x"))).status).toBe(404);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await GET(makeGet("?userId=u9"))).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await GET(makeGet("?userId=u9"))).status).toBe(403);
+  });
+});
+
+describe("POST /api/evaluation-settings", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const validBody = { userId: "u9", fiscalYear: 2025, selfEvaluationEnabled: true };
+
+  it("upsert して 200 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(upsertEvaluationSetting).mockResolvedValue(setting);
+
+    const res = await POST(makePost(validBody));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual(setting);
+    expect(upsertEvaluationSetting).toHaveBeenCalledWith("u9", 2025, {
+      selfEvaluationEnabled: true,
+    });
+  });
+
+  it("必須欠落・非真偽値・年度範囲外は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makePost({ userId: "u9", fiscalYear: 2025 }))).status).toBe(400);
+    expect((await POST(makePost({ ...validBody, selfEvaluationEnabled: "yes" }))).status).toBe(400);
+    expect((await POST(makePost({ ...validBody, fiscalYear: 1800 }))).status).toBe(400);
+    expect(upsertEvaluationSetting).not.toHaveBeenCalled();
+  });
+
+  it("ユーザー未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(upsertEvaluationSetting).mockRejectedValue(
+      new NotFoundError("ユーザーが見つかりません"),
+    );
+    expect((await POST(makePost(validBody))).status).toBe(404);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await POST(makePost(validBody))).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await POST(makePost(validBody))).status).toBe(403);
+  });
+});

--- a/src/app/api/evaluation-settings/route.ts
+++ b/src/app/api/evaluation-settings/route.ts
@@ -1,0 +1,41 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { jsonError, jsonErrorFromException, unauthorized } from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { getEvaluationSettings, upsertEvaluationSetting } from "@/lib/evaluation-settings";
+import { firstZodError } from "@/lib/schemas/_zod-error";
+import { evaluationSettingUpsertBodySchema } from "@/lib/schemas/evaluation-setting";
+
+export async function GET(req: NextRequest) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const userId = new URL(req.url).searchParams.get("userId");
+  if (!userId) return jsonError("userId は必須です", 400);
+
+  try {
+    const evaluationSettings = await getEvaluationSettings(userId);
+    return NextResponse.json({ evaluationSettings });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const body = await req.json().catch(() => null);
+  const parsed = evaluationSettingUpsertBodySchema.safeParse(body);
+  if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
+
+  try {
+    const setting = await upsertEvaluationSetting(parsed.data.userId, parsed.data.fiscalYear, {
+      selfEvaluationEnabled: parsed.data.selfEvaluationEnabled,
+    });
+    return NextResponse.json(setting);
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/lib/evaluation-assignments.test.ts
+++ b/src/lib/evaluation-assignments.test.ts
@@ -10,6 +10,7 @@ import {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: {
+    user: { findUnique: vi.fn() },
     evaluationAssignment: {
       findMany: vi.fn(),
       findUnique: vi.fn(),
@@ -90,6 +91,7 @@ describe("createEvaluationAssignment", () => {
       evaluateeId: "user-1",
       evaluatorId: "user-2",
     };
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: "user-1" } as never);
     vi.mocked(prisma.evaluationAssignment.findUnique).mockResolvedValue(null);
     vi.mocked(prisma.evaluationAssignment.create).mockResolvedValue(mockCreated as never);
 
@@ -103,6 +105,19 @@ describe("createEvaluationAssignment", () => {
       data: { fiscalYear: 2024, evaluateeId: "user-1", evaluatorId: "user-2" },
     });
     expect(result).toEqual(mockCreated);
+  });
+
+  it("被評価者・評価者が存在しない場合は NotFoundError をスロー", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+
+    await expect(
+      createEvaluationAssignment({
+        fiscalYear: 2024,
+        evaluateeId: "missing",
+        evaluatorId: "user-2",
+      }),
+    ).rejects.toThrow(NotFoundError);
+    expect(prisma.evaluationAssignment.create).not.toHaveBeenCalled();
   });
 
   it("fiscalYear が範囲外の場合は BadRequestError をスロー", async () => {
@@ -128,6 +143,7 @@ describe("createEvaluationAssignment", () => {
   });
 
   it("同一の組み合わせが存在する場合は ConflictError をスロー", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: "user-1" } as never);
     vi.mocked(prisma.evaluationAssignment.findUnique).mockResolvedValue(mockAssignment as never);
 
     await expect(
@@ -140,6 +156,7 @@ describe("createEvaluationAssignment", () => {
   });
 
   it("DB の P2002（同時実行競合）の場合は ConflictError をスロー", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: "user-1" } as never);
     vi.mocked(prisma.evaluationAssignment.findUnique).mockResolvedValue(null);
     vi.mocked(prisma.evaluationAssignment.create).mockRejectedValue(
       new Prisma.PrismaClientKnownRequestError("Unique constraint", {

--- a/src/lib/evaluation-assignments.ts
+++ b/src/lib/evaluation-assignments.ts
@@ -46,6 +46,13 @@ export async function createEvaluationAssignment(data: {
   if (!data.evaluateeId) throw new BadRequestError("evaluateeId は必須です");
   if (!data.evaluatorId) throw new BadRequestError("evaluatorId は必須です");
 
+  const [evaluatee, evaluator] = await Promise.all([
+    prisma.user.findUnique({ where: { id: data.evaluateeId }, select: { id: true } }),
+    prisma.user.findUnique({ where: { id: data.evaluatorId }, select: { id: true } }),
+  ]);
+  if (!evaluatee) throw new NotFoundError("被評価者が見つかりません");
+  if (!evaluator) throw new NotFoundError("評価者が見つかりません");
+
   const existing = await prisma.evaluationAssignment.findUnique({
     where: {
       fiscalYear_evaluateeId_evaluatorId: {
@@ -58,7 +65,13 @@ export async function createEvaluationAssignment(data: {
   if (existing) throw new ConflictError("同一年度・被評価者・評価者の組み合わせがすでに存在します");
 
   try {
-    return await prisma.evaluationAssignment.create({ data });
+    const created = await prisma.evaluationAssignment.create({ data });
+    return {
+      id: created.id,
+      fiscalYear: created.fiscalYear,
+      evaluateeId: created.evaluateeId,
+      evaluatorId: created.evaluatorId,
+    };
   } catch (e) {
     if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002")
       throw new ConflictError("同一年度・被評価者・評価者の組み合わせがすでに存在します");

--- a/src/lib/openapi/document.test.ts
+++ b/src/lib/openapi/document.test.ts
@@ -18,6 +18,9 @@ const EXPECTED_PATHS = [
   "/api/fiscal-years",
   "/api/fiscal-years/{year}",
   "/api/fiscal-years/{year}/lock",
+  "/api/evaluation-assignments",
+  "/api/evaluation-assignments/{id}",
+  "/api/evaluation-settings",
 ];
 
 const HTTP_METHODS = ["get", "post", "patch", "put", "delete"];
@@ -65,7 +68,7 @@ describe("buildOpenApiDocument", () => {
       (n, item) => n + Object.keys(item).filter((k) => HTTP_METHODS.includes(k)).length,
       0,
     );
-    expect(opCount).toBe(21);
+    expect(opCount).toBe(26);
   });
 
   it("各オペレーションに summary と responses がある", () => {
@@ -106,6 +109,13 @@ describe("buildOpenApiDocument", () => {
         "FiscalYearCreate",
         "FiscalYearUpdate",
         "FiscalYearLock",
+        "EvaluationAssignment",
+        "EvaluationAssignmentList",
+        "EvaluationAssignmentCreate",
+        "EvaluationAssignmentCreated",
+        "EvaluationSetting",
+        "EvaluationSettingList",
+        "EvaluationSettingUpsert",
       ]),
     );
   });

--- a/src/lib/openapi/document.ts
+++ b/src/lib/openapi/document.ts
@@ -7,6 +7,12 @@ import {
 } from "@/lib/schemas/category";
 import { errorResponseSchema, reorderBodySchema } from "@/lib/schemas/common";
 import {
+  evaluationAssignmentCreateBodySchema,
+  evaluationAssignmentCreatedSchema,
+  evaluationAssignmentListResponseSchema,
+  evaluationAssignmentResponseSchema,
+} from "@/lib/schemas/evaluation-assignment";
+import {
   evaluationItemCreateBodySchema,
   evaluationItemListResponseSchema,
   evaluationItemResponseSchema,
@@ -14,6 +20,11 @@ import {
   evaluationItemsImportResponseSchema,
   evaluationItemUpdateBodySchema,
 } from "@/lib/schemas/evaluation-item";
+import {
+  evaluationSettingListResponseSchema,
+  evaluationSettingResponseSchema,
+  evaluationSettingUpsertBodySchema,
+} from "@/lib/schemas/evaluation-setting";
 import {
   fiscalYearCreateBodySchema,
   fiscalYearListResponseSchema,
@@ -188,6 +199,13 @@ export function buildOpenApiDocument(options: { version?: string; serverUrl?: st
         FiscalYearCreate: toSchema(fiscalYearCreateBodySchema),
         FiscalYearUpdate: toSchema(fiscalYearUpdateBodySchema),
         FiscalYearLock: toSchema(fiscalYearLockBodySchema),
+        EvaluationAssignment: toSchema(evaluationAssignmentResponseSchema),
+        EvaluationAssignmentList: toSchema(evaluationAssignmentListResponseSchema),
+        EvaluationAssignmentCreate: toSchema(evaluationAssignmentCreateBodySchema),
+        EvaluationAssignmentCreated: toSchema(evaluationAssignmentCreatedSchema),
+        EvaluationSetting: toSchema(evaluationSettingResponseSchema),
+        EvaluationSettingList: toSchema(evaluationSettingListResponseSchema),
+        EvaluationSettingUpsert: toSchema(evaluationSettingUpsertBodySchema),
       },
     },
     paths: {
@@ -494,6 +512,101 @@ export function buildOpenApiDocument(options: { version?: string; serverUrl?: st
             401: errorResponse("認証エラー"),
             403: errorResponse("ADMIN 権限が必要"),
             404: errorResponse("未存在"),
+          },
+        },
+      },
+      "/api/evaluation-assignments": {
+        get: {
+          summary: "評価者アサイン一覧を取得",
+          tags: ["evaluation-assignments"],
+          parameters: [
+            {
+              name: "fiscalYear",
+              in: "query",
+              required: false,
+              schema: { type: "integer" },
+              description: "年度で絞り込む",
+            },
+            {
+              name: "evaluateeId",
+              in: "query",
+              required: false,
+              schema: { type: "string" },
+              description: "被評価者 ID で絞り込む",
+            },
+          ],
+          responses: {
+            200: jsonResponse("アサインの一覧", ref("EvaluationAssignmentList")),
+            400: errorResponse("クエリ不正"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+          },
+        },
+        post: {
+          summary: "評価者アサインを作成",
+          tags: ["evaluation-assignments"],
+          requestBody: jsonBody("EvaluationAssignmentCreate"),
+          responses: {
+            201: jsonResponse("作成されたアサイン", ref("EvaluationAssignmentCreated")),
+            400: errorResponse("バリデーションエラー"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            409: errorResponse("同一年度・被評価者・評価者の組み合わせが既に存在"),
+          },
+        },
+      },
+      "/api/evaluation-assignments/{id}": {
+        delete: {
+          summary: "評価者アサインを削除",
+          tags: ["evaluation-assignments"],
+          parameters: [
+            {
+              name: "id",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+              description: "アサイン ID（UUID）",
+            },
+          ],
+          responses: {
+            204: { description: "削除成功（ボディなし）" },
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("未存在"),
+          },
+        },
+      },
+      "/api/evaluation-settings": {
+        get: {
+          summary: "ユーザーの自己評価要否設定一覧を取得",
+          tags: ["evaluation-settings"],
+          parameters: [
+            {
+              name: "userId",
+              in: "query",
+              required: true,
+              schema: { type: "string" },
+              description: "対象ユーザー ID",
+            },
+          ],
+          responses: {
+            200: jsonResponse("年度別設定の一覧", ref("EvaluationSettingList")),
+            400: errorResponse("userId 未指定"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("ユーザー未存在"),
+          },
+        },
+        post: {
+          summary: "自己評価要否設定を作成/更新（upsert）",
+          tags: ["evaluation-settings"],
+          requestBody: jsonBody("EvaluationSettingUpsert"),
+          responses: {
+            200: jsonResponse("upsert 後の設定", ref("EvaluationSetting")),
+            400: errorResponse("バリデーションエラー"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("ユーザー未存在"),
           },
         },
       },

--- a/src/lib/openapi/document.ts
+++ b/src/lib/openapi/document.ts
@@ -551,6 +551,7 @@ export function buildOpenApiDocument(options: { version?: string; serverUrl?: st
             400: errorResponse("バリデーションエラー"),
             401: errorResponse("認証エラー"),
             403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("指定した被評価者・評価者が未存在"),
             409: errorResponse("同一年度・被評価者・評価者の組み合わせが既に存在"),
           },
         },

--- a/src/lib/schemas/common.ts
+++ b/src/lib/schemas/common.ts
@@ -21,6 +21,20 @@ export const positiveIntField = (label: string) =>
     .int({ error: `${label} は整数で指定してください` })
     .min(1, { error: `${label} は 1 以上で指定してください` });
 
+/** 年度フィールド（1900〜9999 の整数）。assignment・setting 等で共用。 */
+export const fiscalYearField = z
+  .number({
+    error: (iss) =>
+      iss.input === undefined ? "fiscalYear は必須です" : "fiscalYear は数値で指定してください",
+  })
+  .int({ error: "fiscalYear は整数で指定してください" })
+  .min(1900, { error: "fiscalYear は 1900〜9999 で指定してください" })
+  .max(9999, { error: "fiscalYear は 1900〜9999 で指定してください" });
+
+/** 非空の ID 文字列フィールド（UUID 等）。 */
+export const nonEmptyIdField = (label: string) =>
+  z.string({ error: `${label} は必須です` }).min(1, { error: `${label} は必須です` });
+
 /**
  * 並び替え（reorder）の body スキーマ。`{ orders: [{ id, index }] }`。
  * targets / categories / evaluation-items で共用する。id・index は整数。

--- a/src/lib/schemas/evaluation-assignment.ts
+++ b/src/lib/schemas/evaluation-assignment.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import { fiscalYearField, nonEmptyIdField } from "@/lib/schemas/common";
+
+/**
+ * 評価者アサインの作成 body。年度・被評価者・評価者を指定。
+ * 重複(409) は lib（`createEvaluationAssignment`）が担保する。
+ */
+export const evaluationAssignmentCreateBodySchema = z.object(
+  {
+    fiscalYear: fiscalYearField,
+    evaluateeId: nonEmptyIdField("evaluateeId"),
+    evaluatorId: nonEmptyIdField("evaluatorId"),
+  },
+  { error: "リクエストボディが不正です" },
+);
+
+const userRef = z.object({ id: z.string(), name: z.string() });
+
+/** アサインのレスポンス（GET 一覧・評価者/被評価者の名前をネスト）。 */
+export const evaluationAssignmentResponseSchema = z.object({
+  id: z.string(),
+  fiscalYear: z.number().int(),
+  evaluatee: userRef,
+  evaluator: userRef,
+});
+
+/** 作成レスポンス（flat・lib の create 返却形）。 */
+export const evaluationAssignmentCreatedSchema = z.object({
+  id: z.string(),
+  fiscalYear: z.number().int(),
+  evaluateeId: z.string(),
+  evaluatorId: z.string(),
+});
+
+/** GET /api/evaluation-assignments のレスポンス（一覧ラッパ）。 */
+export const evaluationAssignmentListResponseSchema = z.object({
+  evaluationAssignments: z.array(evaluationAssignmentResponseSchema),
+});

--- a/src/lib/schemas/evaluation-setting.ts
+++ b/src/lib/schemas/evaluation-setting.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import { fiscalYearField, nonEmptyIdField } from "@/lib/schemas/common";
+
+/**
+ * 自己評価要否設定の upsert body。(userId, fiscalYear) をキーに作成/更新する。
+ */
+export const evaluationSettingUpsertBodySchema = z.object(
+  {
+    userId: nonEmptyIdField("userId"),
+    fiscalYear: fiscalYearField,
+    selfEvaluationEnabled: z.boolean({ error: "selfEvaluationEnabled は真偽値で指定してください" }),
+  },
+  { error: "リクエストボディが不正です" },
+);
+
+/** 設定のレスポンス形式。 */
+export const evaluationSettingResponseSchema = z.object({
+  fiscalYear: z.number().int(),
+  selfEvaluationEnabled: z.boolean(),
+});
+
+/** GET /api/evaluation-settings のレスポンス（一覧ラッパ）。 */
+export const evaluationSettingListResponseSchema = z.object({
+  evaluationSettings: z.array(evaluationSettingResponseSchema),
+});


### PR DESCRIPTION
## Summary

外部 REST API 化 epic（#13 / まとめブランチ `feature/rest-api`）の第5フェーズ。評価者アサイン（evaluation_assignments）と自己評価要否設定（evaluation_settings）を REST API 化する。T211〜214 の契約を踏襲。

### エンドポイント（すべて ADMIN）

**evaluation-assignments**
- `GET /api/evaluation-assignments?fiscalYear=&evaluateeId=`（評価者/被評価者の名前をネスト）
- `POST /api/evaluation-assignments`（201・lib の返却形 flat）
- `DELETE /api/evaluation-assignments/{id}`（204）

**evaluation-settings**
- `GET /api/evaluation-settings?userId=`（`userId` 必須・欠落 400・ユーザー未存在 404）
- `POST /api/evaluation-settings`（upsert・200）

### 実装

- **Zod**: `schemas/evaluation-assignment.ts`・`schemas/evaluation-setting.ts`。共通の `fiscalYearField`（1900-9999）・`nonEmptyIdField` を `common.ts` に集約
- **lib 委譲**: `getEvaluationAssignments`/`createEvaluationAssignment`/`deleteEvaluationAssignment`、`getEvaluationSettings`/`upsertEvaluationSetting`。いずれも lib が API 形を返すため serialize は委譲
- **契約メモ**: assignment は GET が enriched（`evaluatee`/`evaluator` に名前）、POST は lib の create 返却形（flat `evaluateeId`/`evaluatorId`）。upsert は CORS 許可メソッド（GET/POST/PATCH/DELETE）に合わせ **PUT ではなく POST** を採用
- **OpenAPI**: paths・schemas を追記（全 26 オペレーション）

## Test plan

- [x] ユニットテスト 382 passed（各ルート 200/201/204/400/401/403/404/409）
- [x] `next build` で 3 ルート登録確認
- [x] 実 API キーで読み取り検証（401 / ADMIN 200・ネスト整形 / MEMBER 403 / userId 未指定 400 / userId 指定 200） — [結果コメント](https://github.com/ot-nemoto/eval-hub/issues/394#issuecomment-4987207199)
- [x] `/api-reference` に両リソースの表示を確認

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)