### PR TITLE
[T217] users の REST API（一覧・更新・削除）

### DIFF
--- a/src/app/api/users/[id]/route.test.ts
+++ b/src/app/api/users/[id]/route.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/users", () => ({ updateUser: vi.fn(), deleteUser: vi.fn() }));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "@/lib/errors";
+import { deleteUser, updateUser } from "@/lib/users";
+import { DELETE, PATCH } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+
+const updated = {
+  id: "user-2",
+  name: "田中",
+  email: "tanaka@example.com",
+  role: "ADMIN" as const,
+  isActive: true,
+};
+
+function makeRequest(method: string, body?: unknown) {
+  return new Request("http://localhost/api/users/user-2", {
+    method,
+    headers: { "Content-Type": "application/json", authorization: "Bearer key" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  }) as import("next/server").NextRequest;
+}
+
+const ctx = (id = "user-2") => ({ params: Promise.resolve({ id }) });
+
+describe("PATCH /api/users/[id]", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("更新して 200 を返す（currentUserId にキー所有者 id を渡す）", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(updateUser).mockResolvedValue(updated as never);
+
+    const res = await PATCH(makeRequest("PATCH", { role: "ADMIN" }), ctx());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.role).toBe("ADMIN");
+    expect(updateUser).toHaveBeenCalledWith("user-2", { role: "ADMIN" }, "u1");
+  });
+
+  it("自分自身の更新は 403（lib が Forbidden）", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(updateUser).mockRejectedValue(new ForbiddenError("自分自身のロールは変更できません"));
+    expect((await PATCH(makeRequest("PATCH", { role: "MEMBER" }), ctx("u1"))).status).toBe(403);
+  });
+
+  it("空 body は 400（lib が BadRequest）", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(updateUser).mockRejectedValue(new BadRequestError("指定してください"));
+    expect((await PATCH(makeRequest("PATCH", {}), ctx())).status).toBe(400);
+  });
+
+  it("role 不正は 400（Zod）", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await PATCH(makeRequest("PATCH", { role: "SUPER" }), ctx())).status).toBe(400);
+    expect(updateUser).not.toHaveBeenCalled();
+  });
+
+  it("未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(updateUser).mockRejectedValue(new NotFoundError("ユーザーが見つかりません"));
+    expect((await PATCH(makeRequest("PATCH", { role: "ADMIN" }), ctx())).status).toBe(404);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await PATCH(makeRequest("PATCH", { role: "ADMIN" }), ctx())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await PATCH(makeRequest("PATCH", { role: "ADMIN" }), ctx())).status).toBe(403);
+  });
+});
+
+describe("DELETE /api/users/[id]", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("削除して 204 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(deleteUser).mockResolvedValue(undefined);
+
+    const res = await DELETE(makeRequest("DELETE"), ctx());
+    expect(res.status).toBe(204);
+    expect(deleteUser).toHaveBeenCalledWith("user-2", "u1");
+  });
+
+  it("自分自身の削除は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(deleteUser).mockRejectedValue(new ForbiddenError("自分自身は削除できません"));
+    expect((await DELETE(makeRequest("DELETE"), ctx("u1"))).status).toBe(403);
+  });
+
+  it("評価/アサインデータあり（ConflictError）は 409", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(deleteUser).mockRejectedValue(
+      new ConflictError("評価データまたはアサインデータが存在するため削除できません"),
+    );
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(409);
+  });
+
+  it("未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(deleteUser).mockRejectedValue(new NotFoundError("ユーザーが見つかりません"));
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(404);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(403);
+  });
+});

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,5 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { jsonError, jsonErrorFromException, unauthorized } from "@/lib/api-response";
+import {
+  jsonError,
+  jsonErrorFromException,
+  serializeUserUpdate,
+  unauthorized,
+} from "@/lib/api-response";
 import { getAuthenticatedUser } from "@/lib/apiAuth";
 import { firstZodError } from "@/lib/schemas/_zod-error";
 import { userUpdateBodySchema } from "@/lib/schemas/user";
@@ -20,7 +25,7 @@ export async function PATCH(req: NextRequest, { params }: RouteContext) {
 
   try {
     const updated = await updateUser(id, parsed.data, user.id);
-    return NextResponse.json(updated);
+    return NextResponse.json(serializeUserUpdate(updated));
   } catch (e) {
     return jsonErrorFromException(e);
   }

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,0 +1,42 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { jsonError, jsonErrorFromException, unauthorized } from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { firstZodError } from "@/lib/schemas/_zod-error";
+import { userUpdateBodySchema } from "@/lib/schemas/user";
+import { deleteUser, updateUser } from "@/lib/users";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function PATCH(req: NextRequest, { params }: RouteContext) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const { id } = await params;
+
+  const body = await req.json().catch(() => null);
+  const parsed = userUpdateBodySchema.safeParse(body);
+  if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
+
+  try {
+    const updated = await updateUser(id, parsed.data, user.id);
+    return NextResponse.json(updated);
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: RouteContext) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const { id } = await params;
+
+  try {
+    await deleteUser(id, user.id);
+    return new NextResponse(null, { status: 204 });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/app/api/users/route.test.ts
+++ b/src/app/api/users/route.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/users", () => ({ getUsers: vi.fn() }));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { getUsers } from "@/lib/users";
+import { GET } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+
+const libUser = {
+  id: "user-1",
+  name: "田中",
+  email: "tanaka@example.com",
+  role: "MEMBER" as const,
+  division: "開発部",
+  joinedAt: new Date("2020-04-01"),
+  createdAt: new Date("2020-04-01T09:00:00Z"),
+  isActive: true,
+};
+
+function makeGet() {
+  return new Request("http://localhost/api/users", {
+    method: "GET",
+    headers: { authorization: "Bearer key" },
+  }) as import("next/server").NextRequest;
+}
+
+describe("GET /api/users", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("ADMIN は一覧を返す（joinedAt は YYYY-MM-DD・createdAt は ISO）", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(getUsers).mockResolvedValue([libUser] as never);
+
+    const res = await GET(makeGet());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.users[0]).toEqual({
+      id: "user-1",
+      name: "田中",
+      email: "tanaka@example.com",
+      role: "MEMBER",
+      division: "開発部",
+      joinedAt: "2020-04-01",
+      createdAt: "2020-04-01T09:00:00.000Z",
+      isActive: true,
+    });
+  });
+
+  it("joinedAt が null でもそのまま返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(getUsers).mockResolvedValue([{ ...libUser, joinedAt: null }] as never);
+
+    const res = await GET(makeGet());
+    const body = await res.json();
+    expect(body.users[0].joinedAt).toBeNull();
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await GET(makeGet())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await GET(makeGet())).status).toBe(403);
+  });
+});

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,0 +1,17 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { jsonError, jsonErrorFromException, serializeUser, unauthorized } from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { getUsers } from "@/lib/users";
+
+export async function GET(req: NextRequest) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  try {
+    const users = await getUsers();
+    return NextResponse.json({ users: users.map(serializeUser) });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -108,3 +108,28 @@ export function serializeFiscalYear(fy: SerializableFiscalYear) {
     evalItemVersionId: fy.evalItemVersionId,
   };
 }
+
+type SerializableUser = {
+  id: string;
+  name: string;
+  email: string;
+  role: "ADMIN" | "MEMBER";
+  division: string | null;
+  joinedAt: Date | null;
+  createdAt: Date;
+  isActive: boolean;
+};
+
+/** ユーザーを外部 API レスポンス形式に整形する（joinedAt は YYYY-MM-DD、createdAt は ISO）。 */
+export function serializeUser(u: SerializableUser) {
+  return {
+    id: u.id,
+    name: u.name,
+    email: u.email,
+    role: u.role,
+    division: u.division,
+    joinedAt: u.joinedAt ? u.joinedAt.toISOString().slice(0, 10) : null,
+    createdAt: u.createdAt.toISOString(),
+    isActive: u.isActive,
+  };
+}

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -133,3 +133,20 @@ export function serializeUser(u: SerializableUser) {
     isActive: u.isActive,
   };
 }
+
+type SerializableUserUpdate = {
+  id: string;
+  name: string;
+  email: string;
+  role: "ADMIN" | "MEMBER";
+  isActive: boolean;
+};
+
+/**
+ * ユーザー更新レスポンスをホワイトリスト整形する。
+ * secret（apiKey・clerkId）非露出を lib の select だけに依存させず、
+ * 応答経路の単一チョークポイントで担保する。
+ */
+export function serializeUserUpdate(u: SerializableUserUpdate) {
+  return { id: u.id, name: u.name, email: u.email, role: u.role, isActive: u.isActive };
+}

--- a/src/lib/openapi/document.test.ts
+++ b/src/lib/openapi/document.test.ts
@@ -30,6 +30,8 @@ const EXPECTED_PATHS = [
   "/api/evaluations/manager-score",
   "/api/evaluations/comments",
   "/api/evaluations/comments/{id}",
+  "/api/users",
+  "/api/users/{id}",
 ];
 
 const HTTP_METHODS = ["get", "post", "patch", "put", "delete"];
@@ -77,7 +79,7 @@ describe("buildOpenApiDocument", () => {
       (n, item) => n + Object.keys(item).filter((k) => HTTP_METHODS.includes(k)).length,
       0,
     );
-    expect(opCount).toBe(36);
+    expect(opCount).toBe(39);
   });
 
   it("各オペレーションに summary と responses がある", () => {
@@ -137,6 +139,9 @@ describe("buildOpenApiDocument", () => {
         "EvaluationCommentCreate",
         "EvaluationCommentUpdate",
         "ManagerComment",
+        "UserList",
+        "UserUpdate",
+        "UserUpdateResult",
       ]),
     );
   });

--- a/src/lib/openapi/document.ts
+++ b/src/lib/openapi/document.ts
@@ -52,6 +52,11 @@ import {
   targetResponseSchema,
   targetUpdateBodySchema,
 } from "@/lib/schemas/target";
+import {
+  userListResponseSchema,
+  userUpdateBodySchema,
+  userUpdateResponseSchema,
+} from "@/lib/schemas/user";
 
 /**
  * `info.description`（Markdown）に流し込む API 全体のナラティブ。
@@ -259,6 +264,9 @@ export function buildOpenApiDocument(options: { version?: string; serverUrl?: st
         EvaluationCommentCreate: toSchema(evaluationCommentCreateBodySchema),
         EvaluationCommentUpdate: toSchema(evaluationCommentUpdateBodySchema),
         ManagerComment: toSchema(managerCommentResponseSchema),
+        UserList: toSchema(userListResponseSchema),
+        UserUpdate: toSchema(userUpdateBodySchema),
+        UserUpdateResult: toSchema(userUpdateResponseSchema),
       },
     },
     paths: {
@@ -810,6 +818,60 @@ export function buildOpenApiDocument(options: { version?: string; serverUrl?: st
             401: errorResponse("認証エラー"),
             403: errorResponse("ADMIN 権限が必要"),
             404: errorResponse("未存在"),
+          },
+        },
+      },
+      "/api/users": {
+        get: {
+          summary: "ユーザー一覧を取得",
+          tags: ["users"],
+          responses: {
+            200: jsonResponse("ユーザーの一覧", ref("UserList")),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+          },
+        },
+      },
+      "/api/users/{id}": {
+        patch: {
+          summary: "ユーザーのロール・有効フラグを更新",
+          tags: ["users"],
+          parameters: [
+            {
+              name: "id",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+              description: "ユーザー ID（UUID）",
+            },
+          ],
+          requestBody: jsonBody("UserUpdate"),
+          responses: {
+            200: jsonResponse("更新後のユーザー", ref("UserUpdateResult")),
+            400: errorResponse("バリデーションエラー / 更新フィールドなし"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要 / 自分自身は変更不可"),
+            404: errorResponse("未存在"),
+          },
+        },
+        delete: {
+          summary: "ユーザーを削除",
+          tags: ["users"],
+          parameters: [
+            {
+              name: "id",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+              description: "ユーザー ID（UUID）",
+            },
+          ],
+          responses: {
+            204: { description: "削除成功（ボディなし）" },
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要 / 自分自身は削除不可"),
+            404: errorResponse("未存在"),
+            409: errorResponse("評価/アサインデータが存在"),
           },
         },
       },

--- a/src/lib/schemas/user.ts
+++ b/src/lib/schemas/user.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+/** ユーザーのロール。 */
+export const roleSchema = z.enum(["ADMIN", "MEMBER"]);
+
+/**
+ * ユーザー更新 body（role・isActive は任意）。空 body・自分自身の更新は
+ * lib（`updateUser`）が BadRequest→400 / Forbidden→403 を返す。
+ */
+export const userUpdateBodySchema = z.object(
+  {
+    role: roleSchema.optional(),
+    isActive: z.boolean({ error: "isActive は真偽値で指定してください" }).optional(),
+  },
+  { error: "リクエストボディが不正です" },
+);
+
+/** ユーザーのレスポンス形式（一覧）。 */
+export const userResponseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string(),
+  role: roleSchema,
+  division: z.string().nullable(),
+  joinedAt: z.string().nullable(),
+  createdAt: z.string(),
+  isActive: z.boolean(),
+});
+
+/** GET /api/users のレスポンス（一覧ラッパ）。 */
+export const userListResponseSchema = z.object({
+  users: z.array(userResponseSchema),
+});
+
+/** ユーザー更新（PATCH）のレスポンス。 */
+export const userUpdateResponseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string(),
+  role: roleSchema,
+  isActive: z.boolean(),
+});

--- a/src/lib/users.test.ts
+++ b/src/lib/users.test.ts
@@ -22,6 +22,7 @@ vi.mock("@/lib/prisma", () => ({
     evaluationAssignment: { count: vi.fn() },
     evaluation: { count: vi.fn() },
     evaluationSetting: { count: vi.fn() },
+    managerComment: { count: vi.fn() },
   },
 }));
 
@@ -147,6 +148,7 @@ describe("deleteUser", () => {
     vi.mocked(prisma.evaluationAssignment.count).mockResolvedValue(0);
     vi.mocked(prisma.evaluation.count).mockResolvedValue(0);
     vi.mocked(prisma.evaluationSetting.count).mockResolvedValue(0);
+    vi.mocked(prisma.managerComment.count).mockResolvedValue(0);
 
     await deleteUser("user-1", "current-user");
 
@@ -188,6 +190,17 @@ describe("deleteUser", () => {
     vi.mocked(prisma.evaluationSetting.count).mockResolvedValue(1);
 
     await expect(deleteUser("user-1", "current-user")).rejects.toThrow(ConflictError);
+  });
+
+  it("評価者コメントが存在する場合は ConflictError をスロー", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as never);
+    vi.mocked(prisma.evaluationAssignment.count).mockResolvedValue(0);
+    vi.mocked(prisma.evaluation.count).mockResolvedValue(0);
+    vi.mocked(prisma.evaluationSetting.count).mockResolvedValue(0);
+    vi.mocked(prisma.managerComment.count).mockResolvedValue(1);
+
+    await expect(deleteUser("user-1", "current-user")).rejects.toThrow(ConflictError);
+    expect(prisma.user.delete).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -82,15 +82,16 @@ export async function deleteUser(id: string, currentUserId: string) {
   const target = await prisma.user.findUnique({ where: { id } });
   if (!target) throw new NotFoundError("ユーザーが見つかりません");
 
-  const [assignmentCount, evaluationCount, settingCount] = await Promise.all([
+  const [assignmentCount, evaluationCount, settingCount, commentCount] = await Promise.all([
     prisma.evaluationAssignment.count({
       where: { OR: [{ evaluateeId: id }, { evaluatorId: id }] },
     }),
     prisma.evaluation.count({ where: { evaluateeId: id } }),
     prisma.evaluationSetting.count({ where: { userId: id } }),
+    prisma.managerComment.count({ where: { evaluatorId: id } }),
   ]);
 
-  if (assignmentCount > 0 || evaluationCount > 0 || settingCount > 0)
+  if (assignmentCount > 0 || evaluationCount > 0 || settingCount > 0 || commentCount > 0)
     throw new ConflictError("評価データまたはアサインデータが存在するため削除できません");
 
   await prisma.user.delete({ where: { id } });


### PR DESCRIPTION
## Summary

外部 REST API 化 epic（#13 / まとめブランチ `feature/rest-api`）の第7フェーズ。ユーザー管理（一覧・ロール/有効フラグ更新・削除）を REST API 化する。**API キー発行/失効は方針どおりスコープ除外**（発行のみ UI・ログイン必須）。T211〜216 の契約を踏襲。

### エンドポイント（すべて ADMIN）

| メソッド | パス | 説明 |
|---------|------|------|
| GET | `/api/users` | ユーザー一覧 |
| PATCH | `/api/users/{id}` | ロール・有効フラグ更新（200） |
| DELETE | `/api/users/{id}` | 削除（204・評価/アサインデータありは 409） |

### 実装

- **自分自身の保護**: `updateUser`/`deleteUser` は `id === currentUserId` で `ForbiddenError`(403)。`currentUserId` に API キー所有者（`getAuthenticatedUser` の `id`）を渡す
- **secret 非露出**: `userSelect` で管理用フィールド（id/name/email/role/division/joinedAt/createdAt/isActive）のみ返却。`apiKey`/`clerkId` は含めない（実キー検証で `'apiKey' in user === false` を確認）
- **serialize**: `joinedAt`（`@db.Date`・nullable）→ `YYYY-MM-DD`、`createdAt`（timestamp）→ ISO
- **Zod**: `schemas/user.ts`（update body `{ role?, isActive? }`・空は lib が 400、role は enum(`ADMIN`/`MEMBER`)）
- **OpenAPI**: paths・schemas を追記（全 39 オペレーション）

### 対象外

- `updateUserName`（本人の自己サービス）、`generateApiKey`/`revokeApiKey`（UI 専用）

## Test plan

- [x] ユニットテスト 436 passed（各ルート 200/204/400/401/403/404/409、自己更新/自己削除の 403 含む）
- [x] `next build` で 2 ルート登録確認
- [x] 実 API キーで読み取り検証（キーなし 401 / ADMIN 200・apiKey 非露出 / MEMBER 403） — [結果コメント](https://github.com/ot-nemoto/eval-hub/issues/398#issuecomment-4988021647)
- [x] `/api-reference` に users の3オペレーション表示を確認

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)