### PR TITLE
[T218] eval-item-versions の REST API（バージョン管理・年度割当）

### DIFF
--- a/src/app/api/eval-item-versions/[id]/restore/route.test.ts
+++ b/src/app/api/eval-item-versions/[id]/restore/route.test.ts
@@ -12,8 +12,8 @@ import { POST } from "./route";
 const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
 const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
 
-function makeRequest() {
-  return new Request("http://localhost/api/eval-item-versions/1/restore", {
+function makeRequest(query = "?confirm=true") {
+  return new Request(`http://localhost/api/eval-item-versions/1/restore${query}`, {
     method: "POST",
     headers: { authorization: "Bearer key" },
   }) as import("next/server").NextRequest;
@@ -52,6 +52,13 @@ describe("POST /api/eval-item-versions/[id]/restore", () => {
   it("id 不正は 400", async () => {
     vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
     expect((await POST(makeRequest(), ctx("abc"))).status).toBe(400);
+    expect(restoreEvalItemVersion).not.toHaveBeenCalled();
+  });
+
+  it("confirm=true がないと 400（破壊的操作ガード）", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makeRequest(""), ctx())).status).toBe(400);
+    expect((await POST(makeRequest("?confirm=false"), ctx())).status).toBe(400);
     expect(restoreEvalItemVersion).not.toHaveBeenCalled();
   });
 

--- a/src/app/api/eval-item-versions/[id]/restore/route.test.ts
+++ b/src/app/api/eval-item-versions/[id]/restore/route.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/eval-item-versions", () => ({ restoreEvalItemVersion: vi.fn() }));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { BadRequestError, NotFoundError } from "@/lib/errors";
+import { restoreEvalItemVersion } from "@/lib/eval-item-versions";
+import { POST } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+
+function makeRequest() {
+  return new Request("http://localhost/api/eval-item-versions/1/restore", {
+    method: "POST",
+    headers: { authorization: "Bearer key" },
+  }) as import("next/server").NextRequest;
+}
+
+const ctx = (id = "1") => ({ params: Promise.resolve({ id }) });
+
+describe("POST /api/eval-item-versions/[id]/restore", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("復元して 204 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(restoreEvalItemVersion).mockResolvedValue(undefined);
+
+    const res = await POST(makeRequest(), ctx());
+    expect(res.status).toBe(204);
+    expect(restoreEvalItemVersion).toHaveBeenCalledWith(1);
+  });
+
+  it("未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(restoreEvalItemVersion).mockRejectedValue(
+      new NotFoundError("バージョンが見つかりません"),
+    );
+    expect((await POST(makeRequest(), ctx())).status).toBe(404);
+  });
+
+  it("詳細なし（lib BadRequest）は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(restoreEvalItemVersion).mockRejectedValue(
+      new BadRequestError("バージョンに詳細がありません"),
+    );
+    expect((await POST(makeRequest(), ctx())).status).toBe(400);
+  });
+
+  it("id 不正は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makeRequest(), ctx("abc"))).status).toBe(400);
+    expect(restoreEvalItemVersion).not.toHaveBeenCalled();
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await POST(makeRequest(), ctx())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await POST(makeRequest(), ctx())).status).toBe(403);
+  });
+});

--- a/src/app/api/eval-item-versions/[id]/restore/route.ts
+++ b/src/app/api/eval-item-versions/[id]/restore/route.ts
@@ -1,0 +1,29 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { jsonError, jsonErrorFromException, unauthorized } from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { restoreEvalItemVersion } from "@/lib/eval-item-versions";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+function parseId(id: string): number | null {
+  const n = Number(id);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+// 破壊的操作: 指定バージョンの内容で現在のマスタ（targets/categories/evaluation_items）を全消し→復元する。
+export async function POST(req: NextRequest, { params }: RouteContext) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const { id } = await params;
+  const versionId = parseId(id);
+  if (versionId === null) return jsonError("id は正の整数で指定してください", 400);
+
+  try {
+    await restoreEvalItemVersion(versionId);
+    return new NextResponse(null, { status: 204 });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/app/api/eval-item-versions/[id]/restore/route.ts
+++ b/src/app/api/eval-item-versions/[id]/restore/route.ts
@@ -20,6 +20,10 @@ export async function POST(req: NextRequest, { params }: RouteContext) {
   const versionId = parseId(id);
   if (versionId === null) return jsonError("id は正の整数で指定してください", 400);
 
+  // 現在マスタを全消しする不可逆操作のため、明示的な confirm=true を要求して誤爆を防ぐ。
+  if (new URL(req.url).searchParams.get("confirm") !== "true")
+    return jsonError("破壊的操作のため confirm=true を指定してください", 400);
+
   try {
     await restoreEvalItemVersion(versionId);
     return new NextResponse(null, { status: 204 });

--- a/src/app/api/eval-item-versions/[id]/route.test.ts
+++ b/src/app/api/eval-item-versions/[id]/route.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/eval-item-versions", () => ({
+  getEvalItemVersionDetails: vi.fn(),
+  deleteEvalItemVersion: vi.fn(),
+}));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { ConflictError, NotFoundError } from "@/lib/errors";
+import { deleteEvalItemVersion, getEvalItemVersionDetails } from "@/lib/eval-item-versions";
+import { DELETE, GET } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+
+function makeRequest(method: string) {
+  return new Request("http://localhost/api/eval-item-versions/1", {
+    method,
+    headers: { authorization: "Bearer key" },
+  }) as import("next/server").NextRequest;
+}
+
+const ctx = (id = "1") => ({ params: Promise.resolve({ id }) });
+
+describe("GET /api/eval-item-versions/[id]", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("詳細を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(getEvalItemVersionDetails).mockResolvedValue({
+      version: { id: 1, name: "ver1", createdAt: new Date("2026-01-01T00:00:00Z") },
+      details: [],
+    } as never);
+
+    const res = await GET(makeRequest("GET"), ctx());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.version.id).toBe(1);
+    expect(getEvalItemVersionDetails).toHaveBeenCalledWith(1);
+  });
+
+  it("未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(getEvalItemVersionDetails).mockRejectedValue(
+      new NotFoundError("バージョンが見つかりません"),
+    );
+    expect((await GET(makeRequest("GET"), ctx())).status).toBe(404);
+  });
+
+  it("id 不正は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await GET(makeRequest("GET"), ctx("abc"))).status).toBe(400);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await GET(makeRequest("GET"), ctx())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await GET(makeRequest("GET"), ctx())).status).toBe(403);
+  });
+});
+
+describe("DELETE /api/eval-item-versions/[id]", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("削除して 204 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(deleteEvalItemVersion).mockResolvedValue(undefined);
+
+    const res = await DELETE(makeRequest("DELETE"), ctx());
+    expect(res.status).toBe(204);
+    expect(deleteEvalItemVersion).toHaveBeenCalledWith(1);
+  });
+
+  it("年度割当中（ConflictError）は 409", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(deleteEvalItemVersion).mockRejectedValue(
+      new ConflictError("年度に割り当て中のバージョンは削除できません"),
+    );
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(409);
+  });
+
+  it("未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(deleteEvalItemVersion).mockRejectedValue(
+      new NotFoundError("バージョンが見つかりません"),
+    );
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(404);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(403);
+  });
+});

--- a/src/app/api/eval-item-versions/[id]/route.ts
+++ b/src/app/api/eval-item-versions/[id]/route.ts
@@ -1,0 +1,44 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { jsonError, jsonErrorFromException, unauthorized } from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { deleteEvalItemVersion, getEvalItemVersionDetails } from "@/lib/eval-item-versions";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+function parseId(id: string): number | null {
+  const n = Number(id);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+export async function GET(req: NextRequest, { params }: RouteContext) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const { id } = await params;
+  const versionId = parseId(id);
+  if (versionId === null) return jsonError("id は正の整数で指定してください", 400);
+
+  try {
+    return NextResponse.json(await getEvalItemVersionDetails(versionId));
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: RouteContext) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const { id } = await params;
+  const versionId = parseId(id);
+  if (versionId === null) return jsonError("id は正の整数で指定してください", 400);
+
+  try {
+    await deleteEvalItemVersion(versionId);
+    return new NextResponse(null, { status: 204 });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/app/api/eval-item-versions/current/route.test.ts
+++ b/src/app/api/eval-item-versions/current/route.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/eval-item-versions", () => ({ getCurrentEvalItems: vi.fn() }));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { getCurrentEvalItems } from "@/lib/eval-item-versions";
+import { GET } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+
+function makeGet() {
+  return new Request("http://localhost/api/eval-item-versions/current", {
+    method: "GET",
+    headers: { authorization: "Bearer key" },
+  }) as import("next/server").NextRequest;
+}
+
+describe("GET /api/eval-item-versions/current", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("現在のマスタ項目を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(getCurrentEvalItems).mockResolvedValue([] as never);
+
+    const res = await GET(makeGet());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ currentEvalItems: [] });
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await GET(makeGet())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await GET(makeGet())).status).toBe(403);
+  });
+});

--- a/src/app/api/eval-item-versions/current/route.ts
+++ b/src/app/api/eval-item-versions/current/route.ts
@@ -1,0 +1,17 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { jsonError, jsonErrorFromException, unauthorized } from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { getCurrentEvalItems } from "@/lib/eval-item-versions";
+
+export async function GET(req: NextRequest) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  try {
+    const currentEvalItems = await getCurrentEvalItems();
+    return NextResponse.json({ currentEvalItems });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/app/api/eval-item-versions/route.test.ts
+++ b/src/app/api/eval-item-versions/route.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/eval-item-versions", () => ({
+  getEvalItemVersions: vi.fn(),
+  createEvalItemVersion: vi.fn(),
+}));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { BadRequestError } from "@/lib/errors";
+import { createEvalItemVersion, getEvalItemVersions } from "@/lib/eval-item-versions";
+import { GET, POST } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+
+const libVersion = {
+  id: 1,
+  name: "ver1",
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  _count: { details: 10, fiscalYears: 2 },
+};
+
+function makeGet() {
+  return new Request("http://localhost/api/eval-item-versions", {
+    method: "GET",
+    headers: { authorization: "Bearer key" },
+  }) as import("next/server").NextRequest;
+}
+function makePost(body: unknown) {
+  return new Request("http://localhost/api/eval-item-versions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", authorization: "Bearer key" },
+    body: JSON.stringify(body),
+  }) as import("next/server").NextRequest;
+}
+
+describe("GET /api/eval-item-versions", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("一覧を返す（_count を件数に展開・createdAt は ISO）", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(getEvalItemVersions).mockResolvedValue([libVersion] as never);
+
+    const res = await GET(makeGet());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.evalItemVersions[0]).toEqual({
+      id: 1,
+      name: "ver1",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      detailsCount: 10,
+      fiscalYearsCount: 2,
+    });
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await GET(makeGet())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await GET(makeGet())).status).toBe(403);
+  });
+});
+
+describe("POST /api/eval-item-versions", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("作成して 201 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(createEvalItemVersion).mockResolvedValue({
+      id: 1,
+      name: "ver1",
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+    } as never);
+
+    const res = await POST(makePost({ name: "ver1" }));
+    const body = await res.json();
+    expect(res.status).toBe(201);
+    expect(body.name).toBe("ver1");
+    expect(createEvalItemVersion).toHaveBeenCalledWith("ver1");
+  });
+
+  it("name 空は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makePost({ name: "  " }))).status).toBe(400);
+    expect(createEvalItemVersion).not.toHaveBeenCalled();
+  });
+
+  it("評価項目が存在しない（lib BadRequest）は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(createEvalItemVersion).mockRejectedValue(
+      new BadRequestError("評価項目が存在しません"),
+    );
+    expect((await POST(makePost({ name: "ver1" }))).status).toBe(400);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await POST(makePost({ name: "ver1" }))).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await POST(makePost({ name: "ver1" }))).status).toBe(403);
+  });
+});

--- a/src/app/api/eval-item-versions/route.ts
+++ b/src/app/api/eval-item-versions/route.ts
@@ -1,0 +1,41 @@
+import { type NextRequest, NextResponse } from "next/server";
+import {
+  jsonError,
+  jsonErrorFromException,
+  serializeEvalItemVersion,
+  unauthorized,
+} from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { createEvalItemVersion, getEvalItemVersions } from "@/lib/eval-item-versions";
+import { firstZodError } from "@/lib/schemas/_zod-error";
+import { evalItemVersionCreateBodySchema } from "@/lib/schemas/eval-item-version";
+
+export async function GET(req: NextRequest) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  try {
+    const versions = await getEvalItemVersions();
+    return NextResponse.json({ evalItemVersions: versions.map(serializeEvalItemVersion) });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const body = await req.json().catch(() => null);
+  const parsed = evalItemVersionCreateBodySchema.safeParse(body);
+  if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
+
+  try {
+    const version = await createEvalItemVersion(parsed.data.name);
+    return NextResponse.json(version, { status: 201 });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/app/api/fiscal-years/[year]/version/route.test.ts
+++ b/src/app/api/fiscal-years/[year]/version/route.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apiAuth", () => ({ getAuthenticatedUser: vi.fn() }));
+vi.mock("@/lib/eval-item-versions", () => ({
+  assignVersionToFiscalYear: vi.fn(),
+  unassignVersionFromFiscalYear: vi.fn(),
+}));
+
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { ConflictError, NotFoundError } from "@/lib/errors";
+import { assignVersionToFiscalYear, unassignVersionFromFiscalYear } from "@/lib/eval-item-versions";
+import { DELETE, POST } from "./route";
+
+const adminUser = { id: "u1", role: "ADMIN" as const, isActive: true };
+const memberUser = { id: "u2", role: "MEMBER" as const, isActive: true };
+
+function makeRequest(method: string, body?: unknown) {
+  return new Request("http://localhost/api/fiscal-years/2025/version", {
+    method,
+    headers: { "Content-Type": "application/json", authorization: "Bearer key" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  }) as import("next/server").NextRequest;
+}
+
+const ctx = (year = "2025") => ({ params: Promise.resolve({ year }) });
+
+describe("POST /api/fiscal-years/[year]/version", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("割り当てて 200 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(assignVersionToFiscalYear).mockResolvedValue({ year: 2025, evalItemVersionId: 1 });
+
+    const res = await POST(makeRequest("POST", { versionId: 1 }), ctx());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ year: 2025, evalItemVersionId: 1 });
+    expect(assignVersionToFiscalYear).toHaveBeenCalledWith(2025, 1);
+  });
+
+  it("versionId 欠落・不正は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makeRequest("POST", {}), ctx())).status).toBe(400);
+    expect((await POST(makeRequest("POST", { versionId: 0 }), ctx())).status).toBe(400);
+    expect(assignVersionToFiscalYear).not.toHaveBeenCalled();
+  });
+
+  it("年度/バージョン未存在は 404", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(assignVersionToFiscalYear).mockRejectedValue(
+      new NotFoundError("年度が見つかりません"),
+    );
+    expect((await POST(makeRequest("POST", { versionId: 1 }), ctx())).status).toBe(404);
+  });
+
+  it("ロック中（ConflictError）は 409", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(assignVersionToFiscalYear).mockRejectedValue(
+      new ConflictError("この年度はロックされているため編集できません"),
+    );
+    expect((await POST(makeRequest("POST", { versionId: 1 }), ctx())).status).toBe(409);
+  });
+
+  it("year 不正は 400", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    expect((await POST(makeRequest("POST", { versionId: 1 }), ctx("abc"))).status).toBe(400);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await POST(makeRequest("POST", { versionId: 1 }), ctx())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await POST(makeRequest("POST", { versionId: 1 }), ctx())).status).toBe(403);
+  });
+});
+
+describe("DELETE /api/fiscal-years/[year]/version", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("解除して 204 を返す", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(unassignVersionFromFiscalYear).mockResolvedValue({
+      year: 2025,
+      evalItemVersionId: null,
+    });
+
+    const res = await DELETE(makeRequest("DELETE"), ctx());
+    expect(res.status).toBe(204);
+    expect(unassignVersionFromFiscalYear).toHaveBeenCalledWith(2025);
+  });
+
+  it("未存在は 404 / ロック中は 409", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(adminUser);
+    vi.mocked(unassignVersionFromFiscalYear).mockRejectedValue(
+      new NotFoundError("年度が見つかりません"),
+    );
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(404);
+    vi.mocked(unassignVersionFromFiscalYear).mockRejectedValue(
+      new ConflictError("この年度はロックされているため編集できません"),
+    );
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(409);
+  });
+
+  it("キー無効は 401 / MEMBER は 403", async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(null);
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(401);
+    vi.mocked(getAuthenticatedUser).mockResolvedValue(memberUser);
+    expect((await DELETE(makeRequest("DELETE"), ctx())).status).toBe(403);
+  });
+});

--- a/src/app/api/fiscal-years/[year]/version/route.ts
+++ b/src/app/api/fiscal-years/[year]/version/route.ts
@@ -1,0 +1,51 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { jsonError, jsonErrorFromException, unauthorized } from "@/lib/api-response";
+import { getAuthenticatedUser } from "@/lib/apiAuth";
+import { assignVersionToFiscalYear, unassignVersionFromFiscalYear } from "@/lib/eval-item-versions";
+import { firstZodError } from "@/lib/schemas/_zod-error";
+import { versionAssignBodySchema } from "@/lib/schemas/eval-item-version";
+
+type RouteContext = { params: Promise<{ year: string }> };
+
+function parseYear(year: string): number | null {
+  const n = Number(year);
+  return Number.isInteger(n) ? n : null;
+}
+
+export async function POST(req: NextRequest, { params }: RouteContext) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const { year } = await params;
+  const y = parseYear(year);
+  if (y === null) return jsonError("year は整数で指定してください", 400);
+
+  const body = await req.json().catch(() => null);
+  const parsed = versionAssignBodySchema.safeParse(body);
+  if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
+
+  try {
+    const result = await assignVersionToFiscalYear(y, parsed.data.versionId);
+    return NextResponse.json(result);
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: RouteContext) {
+  const user = await getAuthenticatedUser(req);
+  if (!user) return unauthorized();
+  if (user.role !== "ADMIN") return jsonError("権限がありません", 403);
+
+  const { year } = await params;
+  const y = parseYear(year);
+  if (y === null) return jsonError("year は整数で指定してください", 400);
+
+  try {
+    await unassignVersionFromFiscalYear(y);
+    return new NextResponse(null, { status: 204 });
+  } catch (e) {
+    return jsonErrorFromException(e);
+  }
+}

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -150,3 +150,21 @@ type SerializableUserUpdate = {
 export function serializeUserUpdate(u: SerializableUserUpdate) {
   return { id: u.id, name: u.name, email: u.email, role: u.role, isActive: u.isActive };
 }
+
+type SerializableEvalItemVersion = {
+  id: number;
+  name: string;
+  createdAt: Date;
+  _count: { details: number; fiscalYears: number };
+};
+
+/** 評価項目バージョンを外部 API レスポンス形式（_count を件数フィールドに展開）に整形する。 */
+export function serializeEvalItemVersion(v: SerializableEvalItemVersion) {
+  return {
+    id: v.id,
+    name: v.name,
+    createdAt: v.createdAt.toISOString(),
+    detailsCount: v._count.details,
+    fiscalYearsCount: v._count.fiscalYears,
+  };
+}

--- a/src/lib/openapi/document.test.ts
+++ b/src/lib/openapi/document.test.ts
@@ -32,6 +32,11 @@ const EXPECTED_PATHS = [
   "/api/evaluations/comments/{id}",
   "/api/users",
   "/api/users/{id}",
+  "/api/eval-item-versions",
+  "/api/eval-item-versions/current",
+  "/api/eval-item-versions/{id}",
+  "/api/eval-item-versions/{id}/restore",
+  "/api/fiscal-years/{year}/version",
 ];
 
 const HTTP_METHODS = ["get", "post", "patch", "put", "delete"];
@@ -79,7 +84,7 @@ describe("buildOpenApiDocument", () => {
       (n, item) => n + Object.keys(item).filter((k) => HTTP_METHODS.includes(k)).length,
       0,
     );
-    expect(opCount).toBe(39);
+    expect(opCount).toBe(47);
   });
 
   it("各オペレーションに summary と responses がある", () => {
@@ -142,6 +147,13 @@ describe("buildOpenApiDocument", () => {
         "UserList",
         "UserUpdate",
         "UserUpdateResult",
+        "EvalItemVersionList",
+        "EvalItemVersionDetail",
+        "EvalItemVersionCreate",
+        "EvalItemVersionCreated",
+        "CurrentEvalItems",
+        "VersionAssign",
+        "VersionAssignResult",
       ]),
     );
   });

--- a/src/lib/openapi/document.ts
+++ b/src/lib/openapi/document.ts
@@ -953,12 +953,21 @@ export function buildOpenApiDocument(options: { version?: string; serverUrl?: st
       },
       "/api/eval-item-versions/{id}/restore": {
         post: {
-          summary: "バージョンを現在のマスタへ復元（破壊的）",
+          summary: "バージョンを現在のマスタへ復元（破壊的・confirm=true 必須）",
           tags: ["eval-item-versions"],
-          parameters: [idParam],
+          parameters: [
+            idParam,
+            {
+              name: "confirm",
+              in: "query",
+              required: true,
+              schema: { type: "string", enum: ["true"] },
+              description: "破壊的操作の確認。`true` を明示指定しないと 400",
+            },
+          ],
           responses: {
             204: { description: "復元成功（ボディなし）" },
-            400: errorResponse("id 不正 / バージョンに詳細がない"),
+            400: errorResponse("id 不正 / confirm 未指定 / バージョンに詳細がない"),
             401: errorResponse("認証エラー"),
             403: errorResponse("ADMIN 権限が必要"),
             404: errorResponse("未存在"),

--- a/src/lib/openapi/document.ts
+++ b/src/lib/openapi/document.ts
@@ -7,6 +7,15 @@ import {
 } from "@/lib/schemas/category";
 import { errorResponseSchema, reorderBodySchema } from "@/lib/schemas/common";
 import {
+  currentEvalItemsResponseSchema,
+  evalItemVersionCreateBodySchema,
+  evalItemVersionCreatedSchema,
+  evalItemVersionDetailResponseSchema,
+  evalItemVersionListResponseSchema,
+  versionAssignBodySchema,
+  versionAssignResultSchema,
+} from "@/lib/schemas/eval-item-version";
+import {
   evaluationCommentCreateBodySchema,
   evaluationCommentUpdateBodySchema,
   evaluationDetailResponseSchema,
@@ -267,6 +276,13 @@ export function buildOpenApiDocument(options: { version?: string; serverUrl?: st
         UserList: toSchema(userListResponseSchema),
         UserUpdate: toSchema(userUpdateBodySchema),
         UserUpdateResult: toSchema(userUpdateResponseSchema),
+        EvalItemVersionList: toSchema(evalItemVersionListResponseSchema),
+        EvalItemVersionDetail: toSchema(evalItemVersionDetailResponseSchema),
+        EvalItemVersionCreate: toSchema(evalItemVersionCreateBodySchema),
+        EvalItemVersionCreated: toSchema(evalItemVersionCreatedSchema),
+        CurrentEvalItems: toSchema(currentEvalItemsResponseSchema),
+        VersionAssign: toSchema(versionAssignBodySchema),
+        VersionAssignResult: toSchema(versionAssignResultSchema),
       },
     },
     paths: {
@@ -872,6 +888,109 @@ export function buildOpenApiDocument(options: { version?: string; serverUrl?: st
             403: errorResponse("ADMIN 権限が必要 / 自分自身は削除不可"),
             404: errorResponse("未存在"),
             409: errorResponse("評価/アサインデータが存在"),
+          },
+        },
+      },
+      "/api/eval-item-versions": {
+        get: {
+          summary: "評価項目バージョン一覧を取得",
+          tags: ["eval-item-versions"],
+          responses: {
+            200: jsonResponse("バージョンの一覧", ref("EvalItemVersionList")),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+          },
+        },
+        post: {
+          summary: "現在のマスタからバージョンを作成（スナップショット）",
+          tags: ["eval-item-versions"],
+          requestBody: jsonBody("EvalItemVersionCreate"),
+          responses: {
+            201: jsonResponse("作成されたバージョン", ref("EvalItemVersionCreated")),
+            400: errorResponse("バリデーションエラー / 評価項目が存在しない"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+          },
+        },
+      },
+      "/api/eval-item-versions/current": {
+        get: {
+          summary: "現在のマスタのスナップショット相当を取得",
+          tags: ["eval-item-versions"],
+          responses: {
+            200: jsonResponse("現在のマスタ項目", ref("CurrentEvalItems")),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+          },
+        },
+      },
+      "/api/eval-item-versions/{id}": {
+        get: {
+          summary: "バージョン詳細を取得",
+          tags: ["eval-item-versions"],
+          parameters: [idParam],
+          responses: {
+            200: jsonResponse("バージョンと詳細", ref("EvalItemVersionDetail")),
+            400: errorResponse("id 不正"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("未存在"),
+          },
+        },
+        delete: {
+          summary: "バージョンを削除",
+          tags: ["eval-item-versions"],
+          parameters: [idParam],
+          responses: {
+            204: { description: "削除成功（ボディなし）" },
+            400: errorResponse("id 不正"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("未存在"),
+            409: errorResponse("年度に割り当て中"),
+          },
+        },
+      },
+      "/api/eval-item-versions/{id}/restore": {
+        post: {
+          summary: "バージョンを現在のマスタへ復元（破壊的）",
+          tags: ["eval-item-versions"],
+          parameters: [idParam],
+          responses: {
+            204: { description: "復元成功（ボディなし）" },
+            400: errorResponse("id 不正 / バージョンに詳細がない"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("未存在"),
+          },
+        },
+      },
+      "/api/fiscal-years/{year}/version": {
+        post: {
+          summary: "年度に評価項目バージョンを割り当てる",
+          tags: ["fiscal-years"],
+          parameters: [yearParam],
+          requestBody: jsonBody("VersionAssign"),
+          responses: {
+            200: jsonResponse("割当後の年度", ref("VersionAssignResult")),
+            400: errorResponse("バリデーションエラー / year 不正"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("年度・バージョンが未存在"),
+            409: errorResponse("年度がロック中"),
+          },
+        },
+        delete: {
+          summary: "年度のバージョン割当を解除",
+          tags: ["fiscal-years"],
+          parameters: [yearParam],
+          responses: {
+            204: { description: "解除成功（ボディなし）" },
+            400: errorResponse("year 不正"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("ADMIN 権限が必要"),
+            404: errorResponse("年度が未存在"),
+            409: errorResponse("年度がロック中"),
           },
         },
       },

--- a/src/lib/schemas/eval-item-version.ts
+++ b/src/lib/schemas/eval-item-version.ts
@@ -1,0 +1,88 @@
+import { z } from "zod";
+import { nameField, positiveIntField } from "@/lib/schemas/common";
+
+/** バージョン作成 body。現在のマスタからスナップショットを作る。 */
+export const evalItemVersionCreateBodySchema = z.object(
+  { name: nameField },
+  { error: "リクエストボディが不正です" },
+);
+
+/** 年度へのバージョン割当 body。 */
+export const versionAssignBodySchema = z.object(
+  { versionId: positiveIntField("versionId") },
+  { error: "リクエストボディが不正です" },
+);
+
+/** バージョンのレスポンス（一覧・件数付き）。 */
+export const evalItemVersionResponseSchema = z.object({
+  id: z.number().int(),
+  name: z.string(),
+  createdAt: z.string(),
+  detailsCount: z.number().int(),
+  fiscalYearsCount: z.number().int(),
+});
+
+/** GET /api/eval-item-versions のレスポンス（一覧ラッパ）。 */
+export const evalItemVersionListResponseSchema = z.object({
+  evalItemVersions: z.array(evalItemVersionResponseSchema),
+});
+
+/** バージョン詳細 1 件のスナップショット。 */
+const versionDetailSchema = z.object({
+  id: z.number().int(),
+  evaluationItemId: z.number().int().nullable(),
+  targetId: z.number().int(),
+  categoryId: z.number().int(),
+  no: z.number().int(),
+  name: z.string(),
+  description: z.string().nullable(),
+  evalCriteria: z.string().nullable(),
+  index: z.number().int(),
+  targetNo: z.number().int(),
+  targetName: z.string(),
+  targetIndex: z.number().int(),
+  categoryNo: z.number().int(),
+  categoryName: z.string(),
+  categoryIndex: z.number().int(),
+});
+
+/** GET /api/eval-item-versions/{id} のレスポンス。 */
+export const evalItemVersionDetailResponseSchema = z.object({
+  version: z.object({ id: z.number().int(), name: z.string(), createdAt: z.string() }),
+  details: z.array(versionDetailSchema),
+});
+
+/** 作成レスポンス。 */
+export const evalItemVersionCreatedSchema = z.object({
+  id: z.number().int(),
+  name: z.string(),
+  createdAt: z.string(),
+});
+
+/** 現在のマスタスナップショット（GET /api/eval-item-versions/current）。 */
+export const currentEvalItemsResponseSchema = z.object({
+  currentEvalItems: z.array(
+    z.object({
+      evaluationItemId: z.number().int(),
+      targetId: z.number().int(),
+      categoryId: z.number().int(),
+      no: z.number().int(),
+      name: z.string(),
+      description: z.string().nullable(),
+      evalCriteria: z.string().nullable(),
+      index: z.number().int(),
+      targetNo: z.number().int(),
+      targetName: z.string(),
+      targetIndex: z.number().int(),
+      categoryNo: z.number().int(),
+      categoryName: z.string(),
+      categoryIndex: z.number().int(),
+    }),
+  ),
+});
+
+/** 年度割当のレスポンス。 */
+export const versionAssignResultSchema = z.object({
+  year: z.number().int(),
+  evalItemVersionId: z.number().int().nullable(),
+});


### PR DESCRIPTION
## Summary

外部 REST API 化 epic（#13 / まとめブランチ `feature/rest-api`）の第8フェーズ（最終リソース）。評価項目バージョン（スナップショット）の管理と、年度へのバージョン割当を REST API 化する。T211〜217 の契約を踏襲。

### エンドポイント（すべて ADMIN）

**eval-item-versions**
- `GET /api/eval-item-versions`（一覧・詳細/割当年度の件数付き）
- `POST /api/eval-item-versions`（現在マスタからスナップショット作成・201）
- `GET /api/eval-item-versions/current`（現在マスタのスナップショット相当）
- `GET /api/eval-item-versions/{id}`（詳細）／`DELETE`（削除・204・年度割当中は 409）
- `POST /api/eval-item-versions/{id}/restore`（現在マスタへ復元・204・**破壊的**）

**年度割当（fiscal-years 配下）**
- `POST /api/fiscal-years/{year}/version`（割当・`{ versionId }`・200・ロック中 409）
- `DELETE /api/fiscal-years/{year}/version`（解除・204・ロック中 409）

### 実装

- **serialize**: 一覧の `_count` を `detailsCount`/`fiscalYearsCount` に展開（`serializeEvalItemVersion`）。`createdAt` は ISO（`NextResponse.json` 自動）
- **パス命名**: `/current`（静的）は `/{id}`（動的・integer）より優先される。build の route 一覧と実キー検証で衝突なしを確認
- **割当の配置**: 「年度がバージョンを持つ」関係のため `/api/fiscal-years/{year}/version` に配置（lib は eval-item-versions の assign/unassign を委譲）
- **OpenAPI**: paths・schemas を追記（全 47 オペレーション）

## Test plan

- [x] ユニットテスト 467 passed（各ルート 200/201/204/400/401/403/404/409）
- [x] `next build` で 5 ルート登録確認（`/current` が `/[id]` より前）
- [x] 実 API キーで読み取り検証（401 / 一覧 200・件数展開 / 詳細 / current / 未存在 404 / MEMBER 403） — [結果コメント](https://github.com/ot-nemoto/eval-hub/issues/400#issuecomment-4988333117)
- [x] `/api-reference` に eval-item-versions（6op）と fiscal-years 配下の version 割当/解除の表示を確認

## 備考

- 書き込み系（作成/削除/**restore（破壊的）**/割当/解除）は実マスタ・年度データを変更するためライブ検証は未実施（ユニットテストでカバー）。

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)