### PR TITLE
[T219] REST API 化 epic のドキュメント総仕上げ

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - 評価者コメントの追加・編集・削除
 - 年度ロック（評価編集の一括制限）
 - ユーザー管理（有効化・無効化・削除）
+- 外部 REST API（API キー認証で、UI を介さずドメイン操作を実行）
 
 詳細は [docs/product.md](docs/product.md) / [docs/ui.md](docs/ui.md) を参照。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,6 +56,14 @@ Client (Browser)
 - Server Actions の仕様は [`docs/actions.md`](actions.md) を参照
 - 外部 REST API は API キー認証で提供する。検証は Zod スキーマ（`src/lib/schemas/`）を単一ソースとし、そこから OpenAPI 3.1 を実行時生成してアプリ内 `/openapi.json`・`/api-reference`（Stoplight・ログイン必須）で配信する。仕様の正はこの配信 spec とし、別途 `docs/api.md` は持たない
 
+### 外部 REST API の契約・規約
+
+- **認可**: 操作対象ユーザーは常にサーバ側（API キー）から解決する（`getAuthenticatedUser`）。マスタ・管理系は ADMIN 限定。API キーの発行/失効とログインは UI 専用で API 化しない（PAT モデル）。
+- **UI と REST の分離**: UI の書き込みは Server Actions を経由し、REST API とは別入口。両者は同じ `src/lib/` のドメイン関数を呼ぶ薄いアダプタとする（ロジックを二重に持たない）。
+- **エラー契約**: すべて `{ error: string }` を返す。型付きエラー（`NotFound`/`Forbidden`/`Conflict`/`BadRequest`）を `statusForError` で 404/403/409/400 にマッピングし、Prisma の参照/対象欠落（P2003/P2025）は `jsonErrorFromException` で 404 に、想定外は 500（内部情報は隠蔽）に集約する。
+- **CORS**: `/api/*` は API キー認証・Cookie 不使用のため任意オリジン許可（`Access-Control-Allow-Origin: *`）。プリフライト `OPTIONS` は 204（`src/proxy.ts`）。
+- **REST エンドポイント追加手順**: ①ドメイン関数を `src/lib/` に用意（or 既存を再利用）→ ②`src/lib/schemas/` に Zod の body/response スキーマ → ③`src/app/api/**/route.ts` に lib 委譲の薄いアダプタ（認可・Zod 検証・`jsonErrorFromException`）→ ④`src/lib/openapi/document.ts` に paths・schemas を追記。エンドポイント一覧は docs に列挙せず spec を正とする。
+
 ### 機能追加時のガイドライン
 
 | 判断 | 方針 |


### PR DESCRIPTION
## Summary

外部 REST API 化 epic（#13 / まとめブランチ `feature/rest-api`）の最終フェーズ。全 8 リソース・47 オペレーションの API 化完了に伴い、ドキュメントの整合を仕上げる。

- **README.md**: 機能一覧に「外部 REST API（API キー認証でドメイン操作を実行）」を追加
- **docs/architecture.md**: REST API 方針を拡充
  - 認可モデル（ADMIN 限定・キー＝所有者、キー発行/login は非公開の PAT モデル）
  - UI（Server Actions）と REST の分離・共通 lib 委譲
  - エラー契約（`{ error }`・`statusForError`・Prisma P2003/P2025→404 集約）
  - CORS（`/api/*` 任意オリジン・OPTIONS 204）
  - REST エンドポイント追加手順（lib 委譲 + Zod schema + `openapi/document.ts` に追記）

API 仕様の正は配信 spec（`/openapi.json`・`/api-reference`）とし、docs にエンドポイントを列挙しない（source of truth 原則。`docs/api.md` は持たない）。

## Test plan

- docs-only（`.md`）変更のためライブ動作確認は不要
- epic 最終確認: 全 468 ユニットテスト green / `next build` で全 `/api/*` ルート登録 / OpenAPI 47 オペレーション

## 備考

- 本 PR マージで epic の全フェーズ（T211〜T219）が `feature/rest-api` に揃う。次は `feature/rest-api` → `develop` の統合 PR。

Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)