### PR TITLE
fix: テストモックの型不整合を修正しnext buildの型チェックを通す

### DIFF
--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -45,13 +45,12 @@ describe("getSession", () => {
     });
 
     it("MOCK_USER_ID に対応する DB ユーザーのセッションを返す", async () => {
-      // @ts-expect-error
       mockFindUnique.mockResolvedValue({
         id: "mock-user-id",
         name: "モックユーザー",
         role: "ADMIN",
         isActive: true,
-      });
+      } as never);
 
       const result = await getSession();
       expect(result).toEqual({
@@ -65,7 +64,6 @@ describe("getSession", () => {
     });
 
     it("MOCK_USER_ID に対応する DB ユーザーが存在しない場合は null を返す", async () => {
-      // @ts-expect-error
       mockFindUnique.mockResolvedValue(null);
 
       const result = await getSession();
@@ -74,13 +72,12 @@ describe("getSession", () => {
     });
 
     it("isActive: false のユーザーは null を返す", async () => {
-      // @ts-expect-error
       mockFindUnique.mockResolvedValue({
         id: "mock-user-id",
         name: "無効ユーザー",
         role: "MEMBER",
         isActive: false,
-      });
+      } as never);
 
       const result = await getSession();
       expect(result).toBeNull();
@@ -103,13 +100,12 @@ describe("getSession", () => {
     });
 
     it("MOCK_USER_EMAIL に対応する DB ユーザーのセッションを返す", async () => {
-      // @ts-expect-error
       mockFindUnique.mockResolvedValue({
         id: "user-uuid",
         name: "モックユーザー",
         role: "MEMBER",
         isActive: true,
-      });
+      } as never);
 
       const result = await getSession();
       expect(result).toEqual({ user: { id: "user-uuid", name: "モックユーザー", role: "MEMBER" } });
@@ -121,7 +117,6 @@ describe("getSession", () => {
     });
 
     it("MOCK_USER_EMAIL に対応する DB ユーザーが存在しない場合は null を返す", async () => {
-      // @ts-expect-error
       mockFindUnique.mockResolvedValue(null);
 
       const result = await getSession();
@@ -130,13 +125,12 @@ describe("getSession", () => {
     });
 
     it("isActive: false のユーザーは null を返す", async () => {
-      // @ts-expect-error
       mockFindUnique.mockResolvedValue({
         id: "user-uuid",
         name: "無効ユーザー",
         role: "MEMBER",
         isActive: false,
-      });
+      } as never);
 
       const result = await getSession();
       expect(result).toBeNull();
@@ -144,13 +138,12 @@ describe("getSession", () => {
 
     it("MOCK_USER_ID と MOCK_USER_EMAIL が両方設定された場合は MOCK_USER_ID が優先される", async () => {
       process.env.MOCK_USER_ID = "priority-user-id";
-      // @ts-expect-error
       mockFindUnique.mockResolvedValue({
         id: "priority-user-id",
         name: "優先ユーザー",
         role: "ADMIN",
         isActive: true,
-      });
+      } as never);
 
       const result = await getSession();
       expect(mockFindUnique).toHaveBeenCalledWith({
@@ -162,8 +155,7 @@ describe("getSession", () => {
   });
 
   it("Clerkにユーザーがいない場合はnullを返す", async () => {
-    // @ts-expect-error
-    mockAuth.mockResolvedValue({ userId: null });
+    mockAuth.mockResolvedValue({ userId: null } as never);
 
     const result = await getSession();
     expect(result).toBeNull();
@@ -171,15 +163,13 @@ describe("getSession", () => {
   });
 
   it("正常系: clerkIdに対応するDBユーザーが存在する場合はセッションを返す", async () => {
-    // @ts-expect-error
-    mockAuth.mockResolvedValue({ userId: "clerk_abc123" });
-    // @ts-expect-error
+    mockAuth.mockResolvedValue({ userId: "clerk_abc123" } as never);
     mockFindUnique.mockResolvedValue({
       id: "user-uuid",
       name: "テストユーザー",
       role: "MEMBER",
       isActive: true,
-    });
+    } as never);
 
     const result = await getSession();
     expect(result).toEqual({
@@ -189,30 +179,26 @@ describe("getSession", () => {
   });
 
   it("clerkId で見つかったユーザーが isActive: false の場合は null を返す", async () => {
-    // @ts-expect-error
-    mockAuth.mockResolvedValue({ userId: "clerk_abc123" });
-    // @ts-expect-error
+    mockAuth.mockResolvedValue({ userId: "clerk_abc123" } as never);
     mockFindUnique.mockResolvedValue({
       id: "user-uuid",
       name: "無効ユーザー",
       role: "MEMBER",
       isActive: false,
-    });
+    } as never);
 
     const result = await getSession();
     expect(result).toBeNull();
   });
 
   it("adminロールのユーザーも正しく返す", async () => {
-    // @ts-expect-error
-    mockAuth.mockResolvedValue({ userId: "clerk_admin123" });
-    // @ts-expect-error
+    mockAuth.mockResolvedValue({ userId: "clerk_admin123" } as never);
     mockFindUnique.mockResolvedValue({
       id: "admin-uuid",
       name: "管理者",
       role: "ADMIN",
       isActive: true,
-    });
+    } as never);
 
     const result = await getSession();
     expect(result?.user.role).toBe("ADMIN");
@@ -220,24 +206,19 @@ describe("getSession", () => {
 
   describe("初回ログイン時の clerkId 自動紐付け", () => {
     it("メールアドレスが一致するDBユーザーに clerkId を紐付けてセッションを返す", async () => {
-      // @ts-expect-error
-      mockAuth.mockResolvedValue({ userId: "clerk_new123" });
-      // @ts-expect-error
+      mockAuth.mockResolvedValue({ userId: "clerk_new123" } as never);
       mockFindUnique
         .mockResolvedValueOnce(null) // clerkId 検索 → 未ヒット
-        // @ts-expect-error
         .mockResolvedValueOnce({
           id: "user-uuid",
           name: "田中太郎",
           role: "MEMBER",
           clerkId: null,
           isActive: true,
-        }); // email 検索
-      // @ts-expect-error
+        } as never); // email 検索
       mockCurrentUser.mockResolvedValue({
         emailAddresses: [{ emailAddress: "tanaka@example.com" }],
-      });
-      // @ts-expect-error
+      } as never);
       mockUpdateMany.mockResolvedValue({ count: 1 });
 
       const result = await getSession();
@@ -251,31 +232,25 @@ describe("getSession", () => {
     });
 
     it("並行リクエストで先に clerkId が紐付け済みの場合は既存レコードを返す", async () => {
-      // @ts-expect-error
-      mockAuth.mockResolvedValue({ userId: "clerk_new123" });
-      // @ts-expect-error
+      mockAuth.mockResolvedValue({ userId: "clerk_new123" } as never);
       mockFindUnique
         .mockResolvedValueOnce(null) // clerkId 検索 → 未ヒット
-        // @ts-expect-error
         .mockResolvedValueOnce({
           id: "user-uuid",
           name: "田中太郎",
           role: "MEMBER",
           clerkId: null,
           isActive: true,
-        }) // email 検索
-        // @ts-expect-error
+        } as never) // email 検索
         .mockResolvedValueOnce({
           id: "user-uuid",
           name: "田中太郎",
           role: "MEMBER",
           isActive: true,
-        }); // updateMany count=0 後の再取得
-      // @ts-expect-error
+        } as never); // updateMany count=0 後の再取得
       mockCurrentUser.mockResolvedValue({
         emailAddresses: [{ emailAddress: "tanaka@example.com" }],
-      });
-      // @ts-expect-error
+      } as never);
       mockUpdateMany.mockResolvedValue({ count: 0 }); // 別リクエストが先に紐付け済み
 
       const result = await getSession();
@@ -285,21 +260,21 @@ describe("getSession", () => {
     });
 
     it("DBに存在しない新規サインアップユーザーを自動作成してセッションを返す（2人目以降は member）", async () => {
-      // @ts-expect-error
-      mockAuth.mockResolvedValue({ userId: "clerk_new123" });
-      // @ts-expect-error
+      mockAuth.mockResolvedValue({ userId: "clerk_new123" } as never);
       mockFindUnique
         .mockResolvedValueOnce(null) // clerkId 検索 → 未ヒット
         .mockResolvedValueOnce(null); // email 検索 → 未ヒット
-      // @ts-expect-error
       mockCurrentUser.mockResolvedValue({
         emailAddresses: [{ emailAddress: "new@example.com" }],
         fullName: "新規ユーザー",
         firstName: null,
-      });
+      } as never);
       mockCount.mockResolvedValue(1); // 既存ユーザーあり → member
-      // @ts-expect-error
-      mockCreate.mockResolvedValue({ id: "new-uuid", name: "新規ユーザー", role: "MEMBER" });
+      mockCreate.mockResolvedValue({
+        id: "new-uuid",
+        name: "新規ユーザー",
+        role: "MEMBER",
+      } as never);
 
       const result = await getSession();
       expect(result).toEqual({
@@ -318,21 +293,21 @@ describe("getSession", () => {
     });
 
     it("DBにユーザーが0人の場合は初回ユーザーとして admin ロールで作成する", async () => {
-      // @ts-expect-error
-      mockAuth.mockResolvedValue({ userId: "clerk_first123" });
-      // @ts-expect-error
+      mockAuth.mockResolvedValue({ userId: "clerk_first123" } as never);
       mockFindUnique
         .mockResolvedValueOnce(null) // clerkId 検索 → 未ヒット
         .mockResolvedValueOnce(null); // email 検索 → 未ヒット
-      // @ts-expect-error
       mockCurrentUser.mockResolvedValue({
         emailAddresses: [{ emailAddress: "first@example.com" }],
         fullName: "初回ユーザー",
         firstName: null,
-      });
+      } as never);
       mockCount.mockResolvedValue(0); // ユーザー0人 → admin
-      // @ts-expect-error
-      mockCreate.mockResolvedValue({ id: "first-uuid", name: "初回ユーザー", role: "ADMIN" });
+      mockCreate.mockResolvedValue({
+        id: "first-uuid",
+        name: "初回ユーザー",
+        role: "ADMIN",
+      } as never);
 
       const result = await getSession();
       expect(result).toEqual({
@@ -350,23 +325,19 @@ describe("getSession", () => {
     });
 
     it("既に別の clerkId に紐付き済みのDBユーザーはnullを返す", async () => {
-      // @ts-expect-error
-      mockAuth.mockResolvedValue({ userId: "clerk_new123" });
-      // @ts-expect-error
+      mockAuth.mockResolvedValue({ userId: "clerk_new123" } as never);
       mockFindUnique
         .mockResolvedValueOnce(null) // clerkId 検索 → 未ヒット
-        // @ts-expect-error
         .mockResolvedValueOnce({
           id: "user-uuid",
           name: "田中太郎",
           role: "MEMBER",
           clerkId: "clerk_other",
           isActive: true,
-        }); // email 検索 → 別IDに紐付き済み
-      // @ts-expect-error
+        } as never); // email 検索 → 別IDに紐付き済み
       mockCurrentUser.mockResolvedValue({
         emailAddresses: [{ emailAddress: "tanaka@example.com" }],
-      });
+      } as never);
 
       const result = await getSession();
       expect(result).toBeNull();
@@ -374,23 +345,19 @@ describe("getSession", () => {
     });
 
     it("email で見つかったユーザーが isActive: false の場合は null を返す", async () => {
-      // @ts-expect-error
-      mockAuth.mockResolvedValue({ userId: "clerk_new123" });
-      // @ts-expect-error
+      mockAuth.mockResolvedValue({ userId: "clerk_new123" } as never);
       mockFindUnique
         .mockResolvedValueOnce(null) // clerkId 検索 → 未ヒット
-        // @ts-expect-error
         .mockResolvedValueOnce({
           id: "user-uuid",
           name: "無効ユーザー",
           role: "MEMBER",
           clerkId: null,
           isActive: false,
-        }); // email 検索
-      // @ts-expect-error
+        } as never); // email 検索
       mockCurrentUser.mockResolvedValue({
         emailAddresses: [{ emailAddress: "tanaka@example.com" }],
-      });
+      } as never);
 
       const result = await getSession();
       expect(result).toBeNull();
@@ -398,12 +365,9 @@ describe("getSession", () => {
     });
 
     it("Clerkのメールアドレスが取得できない場合はnullを返す", async () => {
-      // @ts-expect-error
-      mockAuth.mockResolvedValue({ userId: "clerk_new123" });
-      // @ts-expect-error
+      mockAuth.mockResolvedValue({ userId: "clerk_new123" } as never);
       mockFindUnique.mockResolvedValueOnce(null);
-      // @ts-expect-error
-      mockCurrentUser.mockResolvedValue({ emailAddresses: [] });
+      mockCurrentUser.mockResolvedValue({ emailAddresses: [] } as never);
 
       const result = await getSession();
       expect(result).toBeNull();

--- a/src/lib/fiscal-years.test.ts
+++ b/src/lib/fiscal-years.test.ts
@@ -165,7 +165,7 @@ describe("updateFiscalYear", () => {
           update: vi.fn().mockResolvedValue({ ...mockFy, name: "更新後" }),
         },
       };
-      return fn(tx);
+      return fn(tx as never);
     });
 
     const result = await updateFiscalYear(2024, { name: "更新後" });


### PR DESCRIPTION
## Summary
- `src/lib/auth.test.ts` の全 `@ts-expect-error` を撤去し、`as never` キャストに統一（`fiscal-years.test.ts` の既存パターンに合わせる）
- `src/lib/fiscal-years.test.ts` の `$transaction` モックの `tx` に `as never` を追加
- CI（`biome ci` + Vitest）は型チェックを行わないため検出されず、`next build` のビルドキャッシュなしフルビルドでのみ表面化していた既存バグ

Closes #424

## Test plan
- [x] `npx tsc --noEmit` でエラーなしを確認
- [x] `npm run test` で全50ファイル・468テストがグリーンであることを確認
- [x] `npx biome check .` でエラーなしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)